### PR TITLE
Exclude BTCPayServer artifacts

### DIFF
--- a/BTCPayServer.Plugins.ArkPayServer/BTCPayServer.Plugins.ArkPayServer.csproj
+++ b/BTCPayServer.Plugins.ArkPayServer/BTCPayServer.Plugins.ArkPayServer.csproj
@@ -26,16 +26,13 @@
     </PropertyGroup>
 
     <!-- This will make sure that referencing BTCPayServer doesn't put any artifact in the published directory -->
-<!--    <ItemDefinitionGroup>-->
-<!--        <ProjectReference>-->
-<!--            <Properties>StaticWebAssetsEnabled=false</Properties>-->
-<!--            <Private>false</Private>-->
-<!--            <ExcludeAssets>runtime;native;build;buildTransitive;contentFiles</ExcludeAssets>-->
-<!--        </ProjectReference>-->
-<!--    </ItemDefinitionGroup>-->
-
-
-
+    <ItemDefinitionGroup>
+        <ProjectReference>
+            <Properties>StaticWebAssetsEnabled=false</Properties>
+            <ExcludeAssets>runtime;native;build;buildTransitive;contentFiles</ExcludeAssets>
+        </ProjectReference>
+    </ItemDefinitionGroup>
+    
     <!-- Workaround for https://github.com/dotnet/roslyn/issues/41640 -->
     <PropertyGroup>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
Exclude BTCPayServer artifacts to fix startup error.

The application does not run on my machine without these configs set, or at least the:
`````
<ExcludeAssets>runtime;native;build;buildTransitive;contentFiles</ExcludeAssets>
`````

Adding it again, since it seems to resolve the issues.