### PR TITLE
Add script for setting up docker environment locally

### DIFF
--- a/start-env.sh
+++ b/start-env.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+
+set -e
+
+log() {
+  local msg="$1"
+  local green="\033[0;32m"
+  local reset="\033[0m"
+  echo -e "${green}[$(date '+%H:%M:%S')] ${msg}${reset}"
+}
+
+# Argument parsing
+ARKD_BRANCH=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --arkd-branch)
+      ARKD_BRANCH="$2"
+      shift 2
+      ;;
+    *)
+      echo "Usage: $0 [--arkd-branch <branch>]" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# Navigate to repository root
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+# 1. Ensure nigiri is installed
+if ! command -v nigiri >/dev/null 2>&1; then
+  log "Nigiri not found. Installing..."
+  curl https://getnigiri.vulpem.com | bash
+else
+  log "Nigiri found: $(nigiri --version)"
+fi
+
+# 2. Stop any running nigiri instances
+log "Stopping existing Nigiri containers..."
+nigiri stop --delete
+log "Removing any previous arkd containers..."
+docker rm -f arkd arkd-wallet 2>/dev/null || true
+
+# 3. Start nigiri and arkd wallet
+if [ -z "$ARKD_BRANCH" ]; then
+  log "Starting Nigiri with Ark support..."
+  nigiri start --ark
+else
+  log "Starting Nigiri without Ark support..."
+  nigiri start
+  TS_SDK_DIR="$SCRIPT_DIR/.cache/ts-sdk-$ARKD_BRANCH"
+  rm -rf "$TS_SDK_DIR"
+  log "Cloning ts-sdk ($ARKD_BRANCH)..."
+  git clone --depth 1 --branch "$ARKD_BRANCH" https://github.com/arkade-os/ts-sdk.git "$TS_SDK_DIR"
+  pushd "$TS_SDK_DIR" >/dev/null
+  docker compose up -d
+  popd >/dev/null
+  rm -rf "$TS_SDK_DIR"
+fi
+log "Nigiri containers running:"
+docker ps \
+  --filter "name=ark" \
+  --filter "name=arkd" \
+  --filter "name=arkd-wallet" \
+  --filter "name=nigiri" \
+  --format "table {{.Names}}\t{{.Status}}"
+
+# 4. Remove previous BTCPayServer dependency containers
+log "Cleaning old BTCPayServer dependencies..."
+pushd submodules/btcpayserver/BTCPayServer.Tests >/dev/null
+if [ -f docker-compose.yml ]; then
+  docker compose down --volumes || true
+fi
+popd >/dev/null
+
+# 5. Start BTCPayServer dependencies
+log "Starting BTCPayServer dependency containers..."
+pushd submodules/btcpayserver/BTCPayServer.Tests >/dev/null
+docker compose up -d dev
+popd >/dev/null
+log "BTCPayServer containers running:"
+docker ps --filter "name=btcpay" --format "table {{.Names}}\t{{.Status}}"
+
+# 6. Unlock arkd wallet
+log "Unlocking arkd wallet..."
+container=""
+if docker ps --format '{{.Names}}' | grep -q '^ark$'; then
+  container="ark"
+elif docker ps --format '{{.Names}}' | grep -q '^arkd$'; then
+  container="arkd"
+fi
+
+if [ -n "$container" ]; then
+  docker exec "$container" arkd wallet create --password secret || true
+  docker exec "$container" arkd wallet unlock --password secret
+  docker exec "$container" arkd wallet status
+  log "arkd wallet unlocked"
+else
+  log "Ark container not running; wallet not unlocked"
+fi
+
+log "✅ Development environment ready."


### PR DESCRIPTION
Add a script called `start-env.sh`

The `start-env.sh` script installs and starts the Ark development environment. Key steps are:

- Install Nigiri if missing using `curl https://getnigiri.vulpem.com | bash`
- Stop existing services and remove leftover containers
- Start Nigiri:
  - With Ark support when no branch is specified
  - Or, when `--arkd-branch <branch>` is supplied, start Nigiri normally, clone that branch of the `ts-sdk` repo, run `docker compose up -d`, then delete the repo
- Clean and restart BTCPayServer dependencies
- Unlock the arkd wallet inside whichever container is running (either ark or arkd)

Usage: run the script from the repository root:

``````
./start-env.sh                              # uses Nigiri’s built-in Ark service
./start-env.sh --arkd-branch <branch-name>  # starts an external arkd service from that branch
``````