### PR TITLE
Migrate to .NET 10

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 10.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/BTCPayServer.Plugins.ArkPayServer/ArkPlugin.cs
+++ b/BTCPayServer.Plugins.ArkPayServer/ArkPlugin.cs
@@ -43,7 +43,7 @@ public class ArkadePlugin : BaseBTCPayServerPlugin
 
     public override IBTCPayServerPlugin.PluginDependency[] Dependencies { get; } =
     [
-        new() { Identifier = nameof(BTCPayServer), Condition = ">=2.3.4" }
+        new() { Identifier = nameof(BTCPayServer), Condition = ">=2.3.7" }
     ];
 
     public override void Execute(IServiceCollection services)

--- a/BTCPayServer.Plugins.ArkPayServer/BTCPayServer.Plugins.ArkPayServer.csproj
+++ b/BTCPayServer.Plugins.ArkPayServer/BTCPayServer.Plugins.ArkPayServer.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 
         <Product>Arkade - Beta</Product>
         <Description>Programmable money for sovereign business. Easily accept payments through Arkade &amp; Lightning non-custodially without complexity.</Description>
-        <Version>2.0.5</Version>
+        <Version>2.1.0</Version>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
         <GenerateRuntimeConfigDevFile>true</GenerateRuntimeConfigDevFile>
@@ -53,21 +53,21 @@
         <PackageReference Include="Cel" Version="0.3.2" />
         <PackageReference Include="Google.Api.CommonProtos" Version="2.17.0" />
         <PackageReference Include="Grpc.Net.Client" Version="2.76.0" />
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.0" />
-        <PackageReference Include="NBitcoin" Version="9.0.4" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.4" />
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.4" />
+        <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.4" />
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.4" />
+        <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.4" />
+        <PackageReference Include="NBitcoin" Version="9.0.5" />
         <PackageReference Include="NBitcoin.Secp256k1" Version="3.2.0" />
         <PackageReference Include="NBXplorer.Client" Version="5.0.5" />
         <!-- Additional packages -->
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <PackageReference Include="Grpc.Net.ClientFactory" Version="2.76.0" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.16"/>
-        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.4"/>
+        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.4" />
         <EmbeddedResource Include="Resources\**" />
         <EmbeddedResource Include="arkade.svg" />
     </ItemGroup>

--- a/BTCPayServer.Plugins.ArkPayServer/Views/Ark/ArkWalletNav.cshtml
+++ b/BTCPayServer.Plugins.ArkPayServer/Views/Ark/ArkWalletNav.cshtml
@@ -10,8 +10,7 @@
 @inject PaymentMethodHandlerDictionary HandlerDictionary 
 @{
     var config =
-        Context
-        .GetStoreData()
+        Model.Store
         .GetPaymentMethodConfig<ArkadePaymentMethodConfig>(
             ArkadePlugin.ArkadePaymentMethodId,
             HandlerDictionary,

--- a/NArk.E2E.Tests/NArk.E2E.Tests.csproj
+++ b/NArk.E2E.Tests/NArk.E2E.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100",
-    "rollForward": "latestMajor"
+    "version": "10.0.100",
+    "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
## Summary

Migrates the Arkade BTCPay plugin to .NET 10 and adds comprehensive DocFX documentation with GitHub Pages deployment.

### .NET 10 Migration

Following the [official migration guide](https://blog.btcpayserver.org/migrating-to-net10/):

- Update target framework from `net8.0` to `net10.0` across plugin and E2E test projects
- Bump btcpayserver submodule to latest master (already on `net10.0`)
- Update NuGet packages to .NET 10-compatible versions (EF Core 10.0.4, Npgsql 10.0.0, Microsoft.Extensions.* 10.0.4, CodeAnalysis 5.3.0, NBitcoin 9.0.5)
- Fix `GetStoreData()` breaking change in nav extension — switched to `Model.Store` via `MainNavViewModel`
- Set minimum BTCPay Server version to `>= 2.3.7` to prevent installation on incompatible .NET 8 instances
- Update CI workflow to .NET 10 SDK
- Bump plugin version to v2.1.0

### Documentation

- Set up [DocFX](https://dotnet.github.io/docfx/) for auto-generated API reference docs (plugin + NNark SDK)
- Add conceptual documentation articles:
  - Getting Started, Architecture, Payment Flows, Wallet Types
  - Ark Protocol Concepts, Configuration Reference, Development Guide
- GitHub Actions workflow deploys docs to GitHub Pages on push to `master`
- Enable XML documentation generation in plugin csproj
- Update README with docs badge and .NET 10 references

### Breaking change addressed

BTCPay Server's `HttpContext.GetStoreData()` now throws `InvalidOperationException` when called outside an authorized store context (e.g., during nav rendering). The `ArkWalletNav.cshtml` nav extension was updated to use `Model.Store` instead.

### NNark submodule

NNark library projects remain on `net8.0` (intentional — they're distributed as NuGet packages and need broad compatibility). .NET 10 apps consume `net8.0` libraries via forward compatibility.

## Test plan

- [x] CI build passes with .NET 10 SDK
- [ ] DocFX builds successfully (verified locally — 0 errors, 634 pages)
- [ ] Plugin loads correctly in BTCPay Server 2.3.7+
- [ ] Arkade nav extension renders without errors
- [ ] Documentation deploys to GitHub Pages after merge to master