### PR TITLE
feat: per-wallet diagnostic log download

### DIFF
--- a/BTCPayServer.Plugins.ArkPayServer/ArkPlugin.cs
+++ b/BTCPayServer.Plugins.ArkPayServer/ArkPlugin.cs
@@ -11,8 +11,10 @@ using BTCPayServer.Plugins.ArkPayServer.Lightning;
 using BTCPayServer.Plugins.ArkPayServer.PaymentHandler;
 using BTCPayServer.Plugins.ArkPayServer.Payouts.Ark;
 using BTCPayServer.Plugins.ArkPayServer.Services;
+using BTCPayServer.Plugins.ArkPayServer.Services.WalletLogger;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using NArk.Abstractions.Blockchain;
 using NArk.Abstractions.Intents;
 using NArk.Abstractions.Safety;
@@ -158,6 +160,21 @@ public class ArkadePlugin : BaseBTCPayServerPlugin
 
     private static void RegisterPluginServices(IServiceCollection services)
     {
+        // Per-wallet diagnostic log store. Captures NArk + plugin log
+        // entries that carry a `WalletId` (either via BeginScope or the
+        // structured-log args) into a rolling file per wallet so the
+        // merchant can download a wallet-scoped log when asking for
+        // support. See Services/WalletLogger/.
+        services.AddSingleton<IWalletLogStore>(sp =>
+        {
+            var configuration = sp.GetRequiredService<IConfiguration>();
+            var dataDir = new DataDirectories().Configure(configuration).DataDir;
+            var logDir = Path.Combine(dataDir, "Plugins", "ArkPayServer", "wallet-logs");
+            return new RollingFileWalletLogStore(logDir, sp.GetService<ILogger<RollingFileWalletLogStore>>());
+        });
+        services.AddSingleton<ILoggerProvider>(sp =>
+            new WalletScopedLoggerProvider(sp.GetRequiredService<IWalletLogStore>()));
+
         services.AddSingleton<ArkadeSpendingService>();
 
         services.AddSingleton<ISweepPolicy, DestinationSweepPolicy>();

--- a/BTCPayServer.Plugins.ArkPayServer/Controllers/ArkController.cs
+++ b/BTCPayServer.Plugins.ArkPayServer/Controllers/ArkController.cs
@@ -17,6 +17,7 @@ using BTCPayServer.Plugins.ArkPayServer.Models.Api;
 using BTCPayServer.Plugins.ArkPayServer.PaymentHandler;
 using BTCPayServer.Plugins.ArkPayServer.Payouts.Ark;
 using BTCPayServer.Plugins.ArkPayServer.Services;
+using BTCPayServer.Plugins.ArkPayServer.Services.WalletLogger;
 using BTCPayServer.Security;
 using BTCPayServer.Services.Invoices;
 using BTCPayServer.Services.Stores;
@@ -82,6 +83,7 @@ public class ArkController(
     IDbContextFactory<ArkPluginDbContext> dbContextFactory,
     IHttpClientFactory httpClientFactory,
     BoardingUtxoSyncService boardingUtxoSyncService,
+    IWalletLogStore walletLogStore,
     ILogger<ArkController> logger) : Controller
 {
     // Post-operation VTXO refresh only needs to catch updates since the operation
@@ -384,6 +386,27 @@ public class ArkController(
             RecentIntents = recentIntents,
             RecentSwaps = recentSwaps
         });
+    }
+
+    [HttpGet("stores/{storeId}/wallet-log")]
+    [Authorize(Policy = Policies.CanModifyStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
+    public async Task<IActionResult> DownloadWalletLog(string storeId)
+    {
+        var (_, config, errorResult) = await ValidateStoreAndConfig();
+        if (errorResult != null) return errorResult;
+
+        var walletId = config!.WalletId!;
+        var stream = walletLogStore.OpenForRead(walletId);
+        if (stream is null)
+        {
+            TempData[WellKnownTempData.SuccessMessage] =
+                "No diagnostic log entries have been recorded for this wallet yet. " +
+                "Use the wallet (send / receive / sync) and try again.";
+            return RedirectToAction(nameof(StoreOverview), new { storeId });
+        }
+
+        var filename = $"arkade-wallet-{walletId}-{DateTime.UtcNow:yyyyMMddTHHmmssZ}.log";
+        return File(stream, "text/plain; charset=utf-8", filename);
     }
 
     [HttpPost("stores/{storeId}/show-private-key")]

--- a/BTCPayServer.Plugins.ArkPayServer/Services/WalletLogger/IWalletLogStore.cs
+++ b/BTCPayServer.Plugins.ArkPayServer/Services/WalletLogger/IWalletLogStore.cs
@@ -1,0 +1,26 @@
+using System.IO;
+
+namespace BTCPayServer.Plugins.ArkPayServer.Services.WalletLogger;
+
+/// <summary>
+/// Per-wallet diagnostic log store. Captures structured log lines tagged
+/// with a WalletId so the merchant can download a wallet-scoped log when
+/// asking for support. Backed by a rolling file on disk in the plugin's
+/// data directory.
+/// </summary>
+public interface IWalletLogStore
+{
+    /// <summary>
+    /// Append a single pre-formatted log line to the given wallet's log.
+    /// Non-blocking: implementations buffer and flush asynchronously, and
+    /// drop oldest entries on backpressure rather than blocking the caller.
+    /// </summary>
+    void Append(string walletId, string line);
+
+    /// <summary>
+    /// Open the wallet's current log file (active rotation slot) for
+    /// reading. Returns null when no log entries have been recorded yet.
+    /// The caller owns the returned stream.
+    /// </summary>
+    Stream? OpenForRead(string walletId);
+}

--- a/BTCPayServer.Plugins.ArkPayServer/Services/WalletLogger/RollingFileWalletLogStore.cs
+++ b/BTCPayServer.Plugins.ArkPayServer/Services/WalletLogger/RollingFileWalletLogStore.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace BTCPayServer.Plugins.ArkPayServer.Services.WalletLogger;
+
+/// <summary>
+/// File-backed implementation of <see cref="IWalletLogStore"/>.
+/// One file per wallet at <c>{logDir}/{walletId}.log</c>, rotated
+/// at 10 MB with up to 3 historical files preserved.
+/// Writes are serialised through a single bounded channel so the calling
+/// thread (which is usually a logger thread on a hot path) never blocks
+/// on disk I/O. On backpressure the oldest pending lines are dropped.
+/// </summary>
+public sealed class RollingFileWalletLogStore : IWalletLogStore, IAsyncDisposable
+{
+    private const long MaxFileSizeBytes = 10L * 1024 * 1024;
+    private const int RotatedFileCount = 3;
+    private const int ChannelCapacity = 4096;
+
+    private readonly string _logDir;
+    private readonly ILogger<RollingFileWalletLogStore>? _logger;
+    private readonly Channel<(string walletId, string line)> _channel;
+    private readonly Task _writerTask;
+    private readonly ConcurrentDictionary<string, StreamWriter> _writers = new(StringComparer.Ordinal);
+    private bool _disposed;
+
+    public RollingFileWalletLogStore(string logDir, ILogger<RollingFileWalletLogStore>? logger = null)
+    {
+        _logDir = logDir;
+        _logger = logger;
+        Directory.CreateDirectory(_logDir);
+        _channel = Channel.CreateBounded<(string, string)>(new BoundedChannelOptions(ChannelCapacity)
+        {
+            FullMode = BoundedChannelFullMode.DropOldest,
+            SingleReader = true,
+            SingleWriter = false,
+        });
+        _writerTask = Task.Run(WriterLoopAsync);
+    }
+
+    public void Append(string walletId, string line)
+    {
+        if (_disposed || string.IsNullOrEmpty(walletId)) return;
+        _channel.Writer.TryWrite((walletId, line));
+    }
+
+    public Stream? OpenForRead(string walletId)
+    {
+        var path = LogPathFor(walletId);
+        if (!File.Exists(path)) return null;
+        return new FileStream(path, FileMode.Open, FileAccess.Read,
+            FileShare.ReadWrite | FileShare.Delete);
+    }
+
+    private string LogPathFor(string walletId) =>
+        Path.Combine(_logDir, Sanitize(walletId) + ".log");
+
+    private static string Sanitize(string walletId)
+    {
+        var invalid = Path.GetInvalidFileNameChars();
+        Span<char> buf = stackalloc char[walletId.Length];
+        for (var i = 0; i < walletId.Length; i++)
+            buf[i] = Array.IndexOf(invalid, walletId[i]) >= 0 ? '_' : walletId[i];
+        return new string(buf);
+    }
+
+    private async Task WriterLoopAsync()
+    {
+        try
+        {
+            await foreach (var (walletId, line) in _channel.Reader.ReadAllAsync())
+            {
+                try
+                {
+                    var writer = GetOrOpenWriter(walletId);
+                    if (writer.BaseStream.Length >= MaxFileSizeBytes)
+                    {
+                        CloseWriter(walletId);
+                        RotateLogFiles(LogPathFor(walletId));
+                        writer = GetOrOpenWriter(walletId);
+                    }
+                    await writer.WriteLineAsync(line);
+                    await writer.FlushAsync();
+                }
+                catch (Exception ex)
+                {
+                    _logger?.LogDebug(ex, "Failed to append wallet log line for {WalletId}", walletId);
+                }
+            }
+        }
+        catch (OperationCanceledException) { }
+    }
+
+    private StreamWriter GetOrOpenWriter(string walletId) =>
+        _writers.GetOrAdd(walletId, id =>
+        {
+            var fs = new FileStream(LogPathFor(id), FileMode.Append, FileAccess.Write,
+                FileShare.Read | FileShare.Delete);
+            return new StreamWriter(fs) { AutoFlush = false };
+        });
+
+    private void CloseWriter(string walletId)
+    {
+        if (_writers.TryRemove(walletId, out var writer))
+        {
+            try { writer.Dispose(); } catch { /* swallow */ }
+        }
+    }
+
+    private static void RotateLogFiles(string path)
+    {
+        for (var i = RotatedFileCount; i > 1; i--)
+        {
+            var older = $"{path}.{i - 1}";
+            var newer = $"{path}.{i}";
+            if (File.Exists(newer)) File.Delete(newer);
+            if (File.Exists(older)) File.Move(older, newer);
+        }
+        var first = $"{path}.1";
+        if (File.Exists(first)) File.Delete(first);
+        if (File.Exists(path)) File.Move(path, first);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        _channel.Writer.TryComplete();
+        try { await _writerTask; } catch { /* swallow */ }
+        foreach (var walletId in _writers.Keys) CloseWriter(walletId);
+    }
+}

--- a/BTCPayServer.Plugins.ArkPayServer/Services/WalletLogger/WalletScopedLogger.cs
+++ b/BTCPayServer.Plugins.ArkPayServer/Services/WalletLogger/WalletScopedLogger.cs
@@ -1,0 +1,148 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+using Microsoft.Extensions.Logging;
+
+namespace BTCPayServer.Plugins.ArkPayServer.Services.WalletLogger;
+
+/// <summary>
+/// Logger created by <see cref="WalletScopedLoggerProvider"/>. Inspects
+/// the active scope chain and the structured log state for a
+/// <c>WalletId</c> property and, if found, appends a formatted line to
+/// the corresponding wallet log via <see cref="IWalletLogStore"/>.
+/// Entries without a discoverable wallet id are dropped — there is no
+/// "shared" log bucket. Add <c>using (logger.BeginScope(("WalletId", id)))</c>
+/// at call sites that don't already pass <c>{WalletId}</c> in their
+/// message template if you want them captured.
+/// </summary>
+internal sealed class WalletScopedLogger : ILogger
+{
+    // Categories whose entries we capture. Anything else is ignored —
+    // there's no value in surfacing BTCPay-core or framework noise in a
+    // wallet diagnostic log.
+    private static readonly string[] CapturedCategoryPrefixes =
+    [
+        "NArk.",
+        "BTCPayServer.Plugins.ArkPayServer.",
+    ];
+
+    private readonly string _category;
+    private readonly IWalletLogStore _store;
+    private readonly bool _categoryCaptured;
+    private IExternalScopeProvider? _scopeProvider;
+
+    public WalletScopedLogger(string category, IWalletLogStore store)
+    {
+        _category = category;
+        _store = store;
+        _categoryCaptured = IsCategoryCaptured(category);
+    }
+
+    public void SetScopeProvider(IExternalScopeProvider scopeProvider) => _scopeProvider = scopeProvider;
+
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull =>
+        _scopeProvider?.Push(state);
+
+    public bool IsEnabled(LogLevel logLevel) =>
+        _categoryCaptured && logLevel >= LogLevel.Debug;
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+        Func<TState, Exception?, string> formatter)
+    {
+        if (!IsEnabled(logLevel)) return;
+
+        var walletId = ResolveWalletId(state);
+        if (walletId is null) return;
+
+        var message = formatter(state, exception);
+        var line = FormatLine(logLevel, _category, eventId, message, exception);
+        _store.Append(walletId, line);
+    }
+
+    private string? ResolveWalletId<TState>(TState state)
+    {
+        // Scope is checked first because it's the explicit form
+        // (`logger.BeginScope(("WalletId", id))`). If a call site sets
+        // both a scope and a structured arg, the scope wins.
+        var walker = new ScopeWalker();
+        _scopeProvider?.ForEachScope(static (scope, w) =>
+        {
+            w.Result ??= ExtractWalletId(scope);
+        }, walker);
+
+        return walker.Result ?? ExtractWalletId(state);
+    }
+
+    private sealed class ScopeWalker { public string? Result { get; set; } }
+
+    private static string? ExtractWalletId(object? source)
+    {
+        if (source is null) return null;
+
+        if (source is IReadOnlyList<KeyValuePair<string, object?>> list)
+        {
+            foreach (var kv in list)
+                if (IsWalletIdKey(kv.Key) && kv.Value is not null)
+                    return kv.Value.ToString();
+        }
+
+        if (source is KeyValuePair<string, object?> single &&
+            IsWalletIdKey(single.Key) && single.Value is not null)
+            return single.Value.ToString();
+
+        if (source is ValueTuple<string, string> stringTuple &&
+            IsWalletIdKey(stringTuple.Item1))
+            return stringTuple.Item2;
+
+        if (source is ValueTuple<string, object> objectTuple &&
+            IsWalletIdKey(objectTuple.Item1))
+            return objectTuple.Item2.ToString();
+
+        return null;
+    }
+
+    private static bool IsWalletIdKey(string key) =>
+        string.Equals(key, "WalletId", StringComparison.Ordinal);
+
+    private static bool IsCategoryCaptured(string category)
+    {
+        foreach (var prefix in CapturedCategoryPrefixes)
+            if (category.StartsWith(prefix, StringComparison.Ordinal)) return true;
+        return false;
+    }
+
+    private static string FormatLine(LogLevel level, string category, EventId eventId,
+        string message, Exception? exception)
+    {
+        var ts = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ", CultureInfo.InvariantCulture);
+        var sb = new StringBuilder(256);
+        sb.Append(ts).Append(' ');
+        sb.Append(LevelTag(level)).Append(' ');
+        sb.Append(category);
+        if (eventId.Id != 0 || !string.IsNullOrEmpty(eventId.Name))
+        {
+            sb.Append('[').Append(eventId.Id);
+            if (!string.IsNullOrEmpty(eventId.Name)) sb.Append(':').Append(eventId.Name);
+            sb.Append(']');
+        }
+        sb.Append(": ").Append(message);
+        if (exception is not null)
+        {
+            sb.AppendLine();
+            sb.Append(exception);
+        }
+        return sb.ToString();
+    }
+
+    private static string LevelTag(LogLevel level) => level switch
+    {
+        LogLevel.Trace => "TRC",
+        LogLevel.Debug => "DBG",
+        LogLevel.Information => "INF",
+        LogLevel.Warning => "WRN",
+        LogLevel.Error => "ERR",
+        LogLevel.Critical => "CRT",
+        _ => "???"
+    };
+}

--- a/BTCPayServer.Plugins.ArkPayServer/Services/WalletLogger/WalletScopedLoggerProvider.cs
+++ b/BTCPayServer.Plugins.ArkPayServer/Services/WalletLogger/WalletScopedLoggerProvider.cs
@@ -1,0 +1,45 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
+
+namespace BTCPayServer.Plugins.ArkPayServer.Services.WalletLogger;
+
+/// <summary>
+/// Logger provider that captures log entries from the NArk and Arkade
+/// plugin categories and routes them to per-wallet log files when a
+/// <c>WalletId</c> is found in the active scope chain or in the log
+/// entry's structured state. Designed to live alongside whatever other
+/// providers (console, file) BTCPay has configured — it doesn't replace
+/// them, it adds a wallet-scoped sink.
+/// </summary>
+[ProviderAlias("ArkadeWalletScoped")]
+public sealed class WalletScopedLoggerProvider : ILoggerProvider, ISupportExternalScope
+{
+    private readonly IWalletLogStore _store;
+    private readonly ConcurrentDictionary<string, WalletScopedLogger> _loggers = new();
+    private IExternalScopeProvider? _scopeProvider;
+
+    public WalletScopedLoggerProvider(IWalletLogStore store)
+    {
+        _store = store;
+    }
+
+    public void SetScopeProvider(IExternalScopeProvider scopeProvider)
+    {
+        _scopeProvider = scopeProvider;
+        foreach (var logger in _loggers.Values) logger.SetScopeProvider(scopeProvider);
+    }
+
+    public ILogger CreateLogger(string categoryName) =>
+        _loggers.GetOrAdd(categoryName, name =>
+        {
+            var logger = new WalletScopedLogger(name, _store);
+            if (_scopeProvider is not null) logger.SetScopeProvider(_scopeProvider);
+            return logger;
+        });
+
+    public void Dispose()
+    {
+        // Loggers hold no per-instance unmanaged state; the store is owned
+        // by DI and will be disposed when the host service provider is.
+    }
+}

--- a/BTCPayServer.Plugins.ArkPayServer/Views/Ark/StoreOverview.cshtml
+++ b/BTCPayServer.Plugins.ArkPayServer/Views/Ark/StoreOverview.cshtml
@@ -146,6 +146,16 @@
                             </button>
                         </div>
                     }
+
+                    <div class="d-flex justify-content-between align-items-center mb-2">
+                        <span class="text-muted">Diagnostic Log</span>
+                        <a asp-action="DownloadWalletLog" asp-route-storeId="@storeId"
+                           class="btn btn-sm badge btn-outline-secondary text-primary"
+                           title="Download this wallet's diagnostic log to share with support"
+                           data-testid="download-wallet-log-btn">
+                            Download
+                        </a>
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary

Adds an opt-in support tool: a rolling per-wallet diagnostic log on disk plus a "Download" button on the store overview that returns the file as `text/plain`. The merchant can then attach it to a support ticket.

## How it works

- **Capture** — A custom `ILoggerProvider` (`WalletScopedLoggerProvider`) inspects every log entry in categories that start with `NArk.` or `BTCPayServer.Plugins.ArkPayServer.`. If a `WalletId` is present in either the active `BeginScope` chain or the structured-log args (`logger.LogInformation("... {WalletId} ...", id)`), the entry is mirrored to that wallet's log. Entries without a discoverable wallet id are dropped — there's no shared bucket.
- **Storage** — `RollingFileWalletLogStore` writes to `{dataDir}/Plugins/ArkPayServer/wallet-logs/{walletId}.log`, rotates at 10 MB with up to 3 historical files (`.log`, `.log.1`, `.log.2`, `.log.3`). All writes are serialised through a single `Channel<...>` (DropOldest on backpressure) so log emission never blocks the calling thread.
- **Download** — `GET /plugins/ark/stores/{storeId}/wallet-log` opens the active log file and streams it back as `text/plain; charset=utf-8`. If nothing has been logged yet for the wallet, it redirects to the overview with a friendly "use the wallet and try again" message.
- **UI** — A "Diagnostic Log → Download" row in the wallet info tile on the store overview page (gated to `CanModifyStoreSettings` like the rest of the overview).

## SDK side: depends on arkade-os/dotnet-sdk#84

That SDK PR adds `BeginScope(("WalletId", id))` at the per-wallet entry points of `SwapsManagementService` (PollSwapState + Initiate/Pay/Restore methods) and `BatchManagementService` (RouteToBatchSessionsAsync + HandleBatchStartedForAllIntentsAsync). Without those scopes, swap status pumps and batch event handlers — which log heavily but mostly with `{SwapId}` / `{IntentId}` only — would fall through the capture filter.

The submodule bump commit (`c8683d7`) points NNark at the SDK feature branch so this PR is testable end-to-end. **Merge order: SDK PR first, then rebase the submodule pointer here to NNark master before merging.**

## Coverage out of the box

`NArk.Core` and `NArk.Swaps` already emit ~62 log lines that carry `{WalletId}` in their message template; the SDK PR adds scopes around the remaining heavy hitters. Together that covers spending, intent generation, batch session lifecycle, swap status pumps, and swap creation. `VtxoSynchronizationService` is intentionally not scoped — its polls/streams span all active wallets at once, so a per-wallet scope would be misleading.

## Files

- `Services/WalletLogger/IWalletLogStore.cs` (new)
- `Services/WalletLogger/RollingFileWalletLogStore.cs` (new)
- `Services/WalletLogger/WalletScopedLogger.cs` (new)
- `Services/WalletLogger/WalletScopedLoggerProvider.cs` (new)
- `ArkPlugin.cs` — DI: register `IWalletLogStore` (factory uses `DataDirectories`) + `ILoggerProvider` → `WalletScopedLoggerProvider`
- `Controllers/ArkController.cs` — new constructor dep `IWalletLogStore`, new action `DownloadWalletLog`
- `Views/Ark/StoreOverview.cshtml` — new "Diagnostic Log → Download" row
- `submodules/NNark` — bumped to `44420fc` (arkade-os/dotnet-sdk#84)

## Test plan

- [x] `dotnet build BTCPayServer.Plugins.ArkPayServer.csproj` — 0 errors
- [x] NNark unit tests — 273/273 pass
- [ ] Smoke test: spin up plugin, pay a Lightning invoice, click Download — verify the file contains the swap / VTXO / batch log lines tagged with the wallet id
- [ ] Smoke test: hit Download with no prior activity — verify the friendly redirect
- [ ] Verify rotation: synthetic load until file > 10 MB, confirm `.log.1` appears and `.log` is fresh
- [ ] CI: build green