### PR TITLE
fix(send): subtract estimated fee from Max amount

### DIFF
--- a/BTCPayServer.Plugins.ArkPayServer/Views/Ark/Send.cshtml
+++ b/BTCPayServer.Plugins.ArkPayServer/Views/Ark/Send.cshtml
@@ -387,7 +387,12 @@ else
             estimatedFee: null,
             isLightning: false,
             hasBitcoinAddress: false,
-            userSpendType: 'Arkade' // User's choice - influences auto coin selection
+            userSpendType: 'Arkade', // User's choice - influences auto coin selection
+            // Set when the user clicks "Max" so that the next estimate-fees
+            // response can revise the amount to (gross - fee). Without this,
+            // batch / collab-exit sends were filled to the full balance and
+            // the user had to subtract the fee by hand to submit.
+            pendingMaxAdjustment: null
         };
 
         // DOM elements
@@ -696,11 +701,31 @@ else
                 const data = await response.json();
 
                 if (data.error) {
+                    state.pendingMaxAdjustment = null;
                     sendBtn.disabled = true;
                     updateReviewContent(data.error);
                 } else {
                     state.estimatedFee = data.estimatedFeeSats;
                     sendBtn.disabled = false;
+
+                    // Apply pending "Max" adjustment: when the user clicked
+                    // Max we filled the gross balance so the fee estimator
+                    // had a real output to price; now we know the fee, so
+                    // revise the amount down to (gross − fee). For Arkade
+                    // (offchain) sends the fee is 0 — nothing to subtract.
+                    if (state.pendingMaxAdjustment !== null) {
+                        const adj = state.pendingMaxAdjustment;
+                        state.pendingMaxAdjustment = null;
+                        if (data.estimatedFeeSats && data.estimatedFeeSats > 0) {
+                            const adjRow = outputsContainer.querySelector(`.output-row[data-index="${adj.index}"]`);
+                            const adjInput = adjRow?.querySelector('.amount-input');
+                            if (adjInput && !adjInput.readOnly) {
+                                const netSats = Math.max(0, adj.grossSats - data.estimatedFeeSats);
+                                adjInput.value = (netSats / 100000000).toFixed(8);
+                                updateRemainingBalance();
+                            }
+                        }
+                    }
 
                     // In auto mode, sync coin checkboxes from server selection
                     if (isAuto && data.selectedOutpoints?.length) {
@@ -723,6 +748,7 @@ else
                     updateReviewSection(reviewCoins, outputs, data);
                 }
             } catch (err) {
+                state.pendingMaxAdjustment = null;
                 console.error('Fee estimation failed:', err);
                 sendBtn.disabled = true;
                 updateReviewContent('Error estimating fee');
@@ -1331,6 +1357,11 @@ else
 
                 const remaining = totalSelectedSats - otherAllocated;
                 if (remaining > 0) {
+                    // Mark this output for fee-aware Max adjustment. The fee
+                    // estimator runs on the dispatched 'input' event below;
+                    // when it returns, the response handler reads this flag
+                    // and revises the value to (gross − estimated fee).
+                    state.pendingMaxAdjustment = { index, grossSats: remaining };
                     amountInput.value = (remaining / 100000000).toFixed(8);
                     amountInput.dispatchEvent(new Event('input', { bubbles: true }));
                 }


### PR DESCRIPTION
## Problem

Reported: "Sending from BTCPay ark screen, when you hit 'Max' to clear a wallet, it doesn't account for the 200 sats fee. So you need to adjust the amount by -200 sats before it processes. (this is when it does a batch collab exit for example)"

The Max button on `Send.cshtml` fills the amount field with `selected_coins_total − other_allocated`, which equals the full input value the resulting transaction has at its disposal — the user is supposed to have ALL of it as output. For an Arkade (off-chain) send that's correct, fee is 0. For a **batch / collab-exit** send the round has a coordinator + miner fee (~200 sats on a typical exit) and the over-spent transaction either fails validation or is rejected by the operator. The user had to subtract by hand to submit.

## Fix

Make Max fee-aware:

1. **On Max click** — set a one-shot `state.pendingMaxAdjustment = { index, grossSats }` flag, fill the gross amount as before, and dispatch the `input` event so the existing debounced `estimate-fees` call fires.
2. **In the `estimate-fees` response handler** — if the pending flag is set and `data.estimatedFeeSats > 0`, revise the same input to `(grossSats − estimatedFeeSats) / 1e8` and refresh `updateRemainingBalance()`. For Arkade sends the fee is 0 — flag is cleared but value isn't touched, so behaviour is unchanged.
3. **Cleanup** — pending flag is cleared on success, on `data.error`, and in the `catch (err)` path so a stale gross can't leak into a later estimation.

UX-wise the user sees Max fill instantly and ~500 ms later (the existing debounce window) the value snaps down by the fee. The Review pane then shows the same fee that was just deducted, so the totals line up.

## Out of scope

`Send2.cshtml` (the alternative simpler send page at `/send2`) has the same conceptual issue, but its Max is server-rendered (`onclick=\"document.getElementById('NewAmountBtc').value = '@Model.AvailableBalanceBtc...'\"`) and the fix path is server-side rather than via the JS estimate-fees flow. Left as a follow-up.

## Files

- `Views/Ark/Send.cshtml` — Max click handler sets the pending flag, fee response handler subtracts, error / catch paths clear the flag.

## Test plan

- [x] `dotnet build BTCPayServer.Plugins.ArkPayServer.csproj` — 0 errors
- [ ] Manual: select all coins, paste a Bitcoin onchain (`bc1...`) destination, click Max → wait briefly → amount should drop by ~200 sats; Review pane should match
- [ ] Manual: same with an `ark1...` destination → amount stays at gross (no fee for Arkade)
- [ ] Manual: select all coins, click Max with no destination → server error path → flag cleared, no stale state on next click
- [ ] CI: build green