### PR TITLE
fix: don't crash plugin when Bitcoin Core RPC blips during Send

### DIFF
--- a/BTCPayServer.Plugins.ArkPayServer/ArkPlugin.cs
+++ b/BTCPayServer.Plugins.ArkPayServer/ArkPlugin.cs
@@ -131,7 +131,11 @@ public class ArkadePlugin : BaseBTCPayServerPlugin
         services.AddSingleton<ChainTimeProvider>(provider =>
         {
             var explorerClientProvider = provider.GetRequiredService<ExplorerClientProvider>();
-            return new ChainTimeProvider(explorerClientProvider.GetExplorerClient("BTC"));
+            // Pass the inner provider's logger so the cache-fallback warning
+            // (emitted when Bitcoin Core RPC blips and we serve a stale
+            // chain time) is visible in plugin logs rather than swallowed.
+            var logger = provider.GetService<Microsoft.Extensions.Logging.ILogger<NArk.Blockchain.NBXplorer.RPCChainTimeProvider>>();
+            return new ChainTimeProvider(explorerClientProvider.GetExplorerClient("BTC"), logger);
         });
         services.AddSingleton<IChainTimeProvider>(sp => sp.GetRequiredService<ChainTimeProvider>());
 


### PR DESCRIPTION
## Problem

Reproduced from a real user testing report:

> Manually sending to Arkade failed at first and crashed the plugin (:see_no_evil:) I had to re-enable it. Second attempt withdrawing worked.

The user's `btcpay-dump.log` shows a clean stack trace:

\`\`\`
fail: Configuration: Unhandled exception caused by plugin 'BTCPayServer.Plugins.ArkPayServer', disabling it and restarting...
System.Net.Http.HttpRequestException: Response status code does not indicate success: 500 (Internal Server Error).
   at NBitcoin.RPC.RPCClient.SendCommandAsync
   at NArk.Blockchain.NBXplorer.RPCChainTimeProvider.GetChainTime
   at ArkController.GetArkBalances
   at ArkController.Send
\`\`\`

`getblockchaininfo` returned a transient 500 from Bitcoin Core. The exception propagated all the way up through `GetArkBalances` → `Send`, BTCPay's plugin manager caught it, **disabled the plugin entirely**, and the user had to manually re-enable it before retrying.

## Fix

The fix lives in NNark ([arkade-os/dotnet-sdk#85](https://github.com/arkade-os/dotnet-sdk/pull/85)) — `RPCChainTimeProvider` now caches the last successful chain time and falls back to it on transient RPC errors, logging a warning instead of throwing. This PR bumps the submodule to pick that up, plus threads `ILogger<RPCChainTimeProvider>` through the plugin's `ChainTimeProvider` DI registration so the fallback warning surfaces in plugin logs.

After this bump:
- Transient Bitcoin Core RPC blip during Send / Send2 / fee-estimation → caller sees a slightly stale chain time (off by minutes during the blip), no crash, no plugin disable.
- Cold-start RPC failure (no cached value yet) still throws — at that point we genuinely have no chain time to report.

## Triage notes on the rest of the user's report

The same dump covered three other observations the user flagged. Walking through each so we have receipts:

1. **"First lightning payment failed (used WoS, just pending for long)"** — the log shows the swap settled on our side: `Swap RNYLpT8hwpkK: status changed Pending -> Settled (Boltz: 'invoice.settled')` after we successfully claimed the VHTLC and produced spend tx `44f03874…`. From Boltz's perspective the customer's Lightning HTLC was claimed (preimage exposed), so the customer's wallet should see the payment as completed. WoS sometimes UI-lags on swap-completion; not a plugin bug. **No action.**
2. **"Autosweep to Arkade didn't work"** — the VHTLC auto-claim DID fire: `Sweep successful for outpoint 6875e069…, txId: 44f03874…`. I suspect this is confusion with the *destination auto-sweep* feature (sweeping to an external address); no destination was configured in this run, so no external sweep was scheduled. **Likely UX/docs, no code change here.** Worth a follow-up to make the two flows distinguishable in the UI.
3. **Noisy "New swap detected, subscribing to websocket updates" loop on a terminal swap** — the log shows it for swap RNYLpT8hwpkK after it reached `Settled`. Already fixed by [arkade-os/dotnet-sdk#83](https://github.com/arkade-os/dotnet-sdk/pull/83) (single persistent Boltz websocket with subscribe/unsubscribe), which landed on NNark master. The user was on plugin v2.1.7.0 which predates that fix; the next plugin version that bumps NNark will resolve it. **No additional action needed beyond shipping a release that includes both #83 and #85.**

## Test plan

- [x] `dotnet build BTCPayServer.Plugins.ArkPayServer.csproj` — 0 errors
- [x] NNark unit tests — 273/273 pass on the SDK side
- [ ] Manual: stop bitcoind RPC mid-flight, hit Send → expect a warning log + slightly stale balance display, plugin stays up
- [ ] Manual: cold-start with bitcoind RPC down → expect Send to surface the error (no cached value to fall back on) but plugin still runs (BTCPay's per-request error path handles the throw)
- [ ] CI: build green