### PR TITLE
feat: tag Boltz swap-creation requests with 'btcpay-arkade' referral

### DIFF
--- a/BTCPayServer.Plugins.ArkPayServer/ArkPlugin.cs
+++ b/BTCPayServer.Plugins.ArkPayServer/ArkPlugin.cs
@@ -198,6 +198,11 @@ public class ArkadePlugin : BaseBTCPayServerPlugin
             services.AddHttpClient<CachedBoltzClient>();
             services.AddArkSwapServices();
 
+            // Tag every Boltz swap-creation request with the BTCPay-Arkade
+            // referral so Boltz can credit the integration. Mirrors the
+            // wallet-side `arkade-money` referral added in arkade-os/wallet#606.
+            services.Configure<NArk.Swaps.Boltz.Models.BoltzClientOptions>(o => o.ReferralId = "btcpay-arkade");
+
             services.AddUIExtension("ln-payment-method-setup-tabhead", "/Views/Ark/ArkLNSetupTabhead.cshtml");
 
             services.AddSingleton<ArkadeLNURLPayRequestFilter>();


### PR DESCRIPTION
## Summary

Mirrors [arkade-os/wallet#606](https://github.com/arkade-os/wallet/pull/606) (which added a \`referralId\` on the JS Boltz swap provider, set to \`arkade-money\`) on the BTCPay plugin side. Boltz uses the referral to credit swaps to the originating integration; tagging BTCPay-Arkade traffic separately from the standalone wallet's \`arkade-money\` traffic gives accurate attribution.

## Wiring

- Bumps NNark submodule to [arkade-os/dotnet-sdk#86](https://github.com/arkade-os/dotnet-sdk/pull/86), which adds an optional \`ReferralId\` on \`BoltzClientOptions\` and stamps it on every swap-creation request (Submarine, Reverse, BTC→ARK chain, ARK→BTC chain).
- In \`ArkPlugin.RegisterBoltzServices\`, registers \`services.Configure<BoltzClientOptions>(o => o.ReferralId = "btcpay-arkade")\` so every Boltz request the plugin emits carries the referral.

Default-null on the SDK side means existing consumers who don't configure the referral see no behaviour change — only this plugin (and the wallet on its side) opt in.

## Files

- \`ArkPlugin.cs\` — one \`services.Configure<BoltzClientOptions>\` line in the Boltz registration block
- \`submodules/NNark\` — bumped to \`6c71f53\` (head of arkade-os/dotnet-sdk#86)

## Test plan

- [x] \`dotnet build BTCPayServer.Plugins.ArkPayServer.csproj\` — 0 errors
- [ ] CI: build green
- [ ] Manual: create a Submarine / Reverse / Chain swap, observe the outgoing request carries \`"referralId": "btcpay-arkade"\`