### PR TITLE
fix(checkout): preserve third-party BIP21 params (PayJoin, Branta) on Arkade tab

### DIFF
--- a/BTCPayServer.Plugins.ArkPayServer/PaymentHandler/ArkadeBip21Builder.cs
+++ b/BTCPayServer.Plugins.ArkPayServer/PaymentHandler/ArkadeBip21Builder.cs
@@ -15,6 +15,14 @@ public class ArkadeBip21Builder
     private string? _lightningInvoice;
     private decimal? _amount;
     private readonly Dictionary<string, string> _customParameters = new();
+    /// <summary>
+    /// Raw <c>key=value</c> entries pulled from another extension's BIP21
+    /// query string (PayJoin's <c>pj=</c>, Branta's <c>branta_*</c>, etc.)
+    /// that we want to forward verbatim — preserving whatever URL-encoding
+    /// the upstream chose, so re-decoding/re-encoding can't mangle the
+    /// values. Populated by <see cref="WithExtraQuery"/>.
+    /// </summary>
+    private readonly List<string> _passthroughEntries = new();
 
     /// <summary>
     /// Sets the Bitcoin onchain address (optional).
@@ -62,8 +70,43 @@ public class ArkadeBip21Builder
     {
         if (string.IsNullOrWhiteSpace(key))
             throw new ArgumentException("Parameter key cannot be null or empty", nameof(key));
-        
+
         _customParameters[key] = value;
+        return this;
+    }
+
+    /// <summary>
+    /// Forwards every <c>key=value</c> entry from another BIP21's query
+    /// string, except keys this builder owns (<c>amount</c>, <c>ark</c>,
+    /// <c>lightning</c>). Used by <c>ArkadePaymentLinkExtension</c> to carry
+    /// PayJoin's <c>pj=</c>, Branta's <c>branta_id</c>/<c>branta_secret</c>,
+    /// and any other plugin's params from the upstream onchain BIP21 into
+    /// the unified Arkade QR.
+    /// </summary>
+    /// <param name="rawQuery">
+    /// The query portion of the upstream URI — with or without the leading
+    /// <c>?</c>. Entries are forwarded verbatim (no decode/re-encode), so
+    /// whatever URL-encoding the upstream chose round-trips byte-for-byte.
+    /// </param>
+    public ArkadeBip21Builder WithExtraQuery(string? rawQuery)
+    {
+        if (string.IsNullOrEmpty(rawQuery)) return this;
+        var trimmed = rawQuery.TrimStart('?');
+        if (trimmed.Length == 0) return this;
+
+        foreach (var pair in trimmed.Split('&', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var eq = pair.IndexOf('=');
+            var key = eq < 0 ? pair : pair[..eq];
+            // Keys we set ourselves win — skip duplicates from upstream so
+            // the wallet doesn't see two `amount=`s or pick up someone else's
+            // ark/lightning value over the one we just computed.
+            if (string.Equals(key, "amount", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(key, "ark", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(key, "lightning", StringComparison.OrdinalIgnoreCase))
+                continue;
+            _passthroughEntries.Add(pair);
+        }
         return this;
     }
 
@@ -106,7 +149,11 @@ public class ArkadeBip21Builder
         {
             parameters.Add($"{HttpUtility.UrlEncode(key)}={HttpUtility.UrlEncode(value)}");
         }
-        
+
+        // Pass-through entries from upstream BIP21s (PayJoin / Branta / ...)
+        // appended verbatim, no re-encoding.
+        parameters.AddRange(_passthroughEntries);
+
         // Join all parameters
         sb.Append(string.Join("&", parameters));
         

--- a/BTCPayServer.Plugins.ArkPayServer/PaymentHandler/ArkadeCheckoutModelExtension.cs
+++ b/BTCPayServer.Plugins.ArkPayServer/PaymentHandler/ArkadeCheckoutModelExtension.cs
@@ -1,5 +1,7 @@
 using BTCPayServer.Data;
+using BTCPayServer.Models.InvoicingModels;
 using BTCPayServer.Payments;
+using BTCPayServer.Services.Invoices;
 using Newtonsoft.Json.Linq;
 
 namespace BTCPayServer.Plugins.ArkPayServer.PaymentHandler;
@@ -7,17 +9,29 @@ namespace BTCPayServer.Plugins.ArkPayServer.PaymentHandler;
 public class ArkadeCheckoutModelExtension: ICheckoutModelExtension, IGlobalCheckoutModelExtension
 {
     private readonly IPaymentLinkExtension _arkadePaymentLinkExtension;
+    private readonly IPaymentLinkExtension? _bitcoinPaymentLinkExtension;
     private readonly ArkadePaymentMethodHandler _handler;
+    private readonly PaymentMethodHandlerDictionary _handlers;
+    private readonly IEnumerable<IGlobalCheckoutModelExtension> _globalExtensions;
+
+    private static readonly PaymentMethodId BitcoinOnchainPmi =
+        PaymentTypes.CHAIN.GetPaymentMethodId("BTC");
 
     public ArkadeCheckoutModelExtension(
         IEnumerable<IPaymentLinkExtension> paymentLinkExtensions,
+        IEnumerable<IGlobalCheckoutModelExtension> globalExtensions,
+        PaymentMethodHandlerDictionary handlers,
         ArkadePaymentMethodHandler handler)
     {
         _handler = handler;
+        _handlers = handlers;
+        _globalExtensions = globalExtensions;
+        var linkList = paymentLinkExtensions as IList<IPaymentLinkExtension> ?? paymentLinkExtensions.ToList();
         _arkadePaymentLinkExtension =
-            paymentLinkExtensions
-                .SingleOrDefault(p => p.PaymentMethodId == ArkadePlugin.ArkadePaymentMethodId) ??
+            linkList.SingleOrDefault(p => p.PaymentMethodId == ArkadePlugin.ArkadePaymentMethodId) ??
             throw new InvalidOperationException("ArkadePaymentLinkExtension not found in DI");
+        _bitcoinPaymentLinkExtension =
+            linkList.SingleOrDefault(p => p.PaymentMethodId == BitcoinOnchainPmi);
     }
     public PaymentMethodId PaymentMethodId => ArkadePlugin.ArkadePaymentMethodId;
 
@@ -36,11 +50,21 @@ public class ArkadeCheckoutModelExtension: ICheckoutModelExtension, IGlobalCheck
             _arkadePaymentLinkExtension.GetPaymentLink(context.Prompt, context.UrlHelper)
                 ?? throw new Exception("Failed to generate Arkade payment link"); // should not happen
 
-        // QR code: uppercase address and values for efficient alphanumeric QR encoding,
-        // keeping parameter keys lowercase per BIP21 spec. Includes lightning= for unified QR.
-        context.Model.InvoiceBitcoinUrlQR = UpperCaseQrUri(paymentLink);
+        // Harvest any params that bitcoin-onchain-only plugins (Branta's
+        // branta_id/branta_secret, payjoin's pj=, future ones that gate on
+        // PaymentMethodId == "BTC-CHAIN") would have appended to the bitcoin
+        // tab's URL. They never see the Arkade tab on their own — we have to
+        // synthesise their pipeline. See HarvestUpstreamGlobalParams below.
+        var (extraForUrl, extraForQr) = HarvestUpstreamGlobalParams(context);
+
         // Full BIP21 with all params for "Pay in wallet" link
-        context.Model.InvoiceBitcoinUrl = paymentLink;
+        context.Model.InvoiceBitcoinUrl = AppendQuery(paymentLink, extraForUrl);
+
+        // QR code: uppercase address + bech32m values for efficient alphanumeric QR encoding,
+        // keeping parameter keys lowercase per BIP21 spec. Includes lightning= for unified QR.
+        // Other plugin-contributed params are forwarded verbatim — uppercasing would mangle
+        // case-sensitive payloads (PayJoin's onion URLs, Branta's base64 secrets, etc.).
+        context.Model.InvoiceBitcoinUrlQR = AppendQuery(UpperCaseQrUri(paymentLink), extraForQr);
 
         // Pass boarding flag to checkout component
         if (context.Prompt.Details is not null)
@@ -49,6 +73,72 @@ public class ArkadeCheckoutModelExtension: ICheckoutModelExtension, IGlobalCheck
             if (!string.IsNullOrEmpty(details.BoardingAddress))
                 context.Model.AdditionalData["hasBoardingAddress"] = JToken.FromObject(true);
         }
+    }
+
+    /// <summary>
+    /// Returns (extraForUrl, extraForQr): the <c>key=value</c> entries that
+    /// other plugins' <see cref="IGlobalCheckoutModelExtension"/> hooks would
+    /// have added to the bitcoin onchain tab's URL had the user been viewing
+    /// that tab. We synthesise a bitcoin-tab CheckoutModel + Context, run the
+    /// rest of the global-extension pipeline against it (skipping ourselves
+    /// to avoid recursion), and diff the resulting URL strings against the
+    /// pristine bitcoin BIP21 to identify what each plugin tacked on.
+    /// </summary>
+    /// <remarks>
+    /// <para>This is a pragmatic workaround for plugins that gate on
+    /// <c>model.PaymentMethodId == "BTC-CHAIN"</c> (notably Branta) and
+    /// therefore never contribute to the Arkade tab. The right long-term fix
+    /// is for those plugins to also recognise the Arkade payment method;
+    /// until then we replay their work on a synthetic context to harvest
+    /// what they would have added.</para>
+    /// <para>The trade-off: any plugin doing more than URL mutation in its
+    /// global hook (DB writes, metrics, cache reads/writes) will see those
+    /// side-effects fire a second time per checkout-page render. Branta's
+    /// hook is pure URL concatenation, so today this is safe. We're
+    /// deliberately accepting the brittleness for the UX win.</para>
+    /// </remarks>
+    private (string ExtraForUrl, string ExtraForQr) HarvestUpstreamGlobalParams(CheckoutModelContext realCtx)
+    {
+        var bitcoinPrompt = realCtx.InvoiceEntity.GetPaymentPrompt(BitcoinOnchainPmi);
+        if (bitcoinPrompt is null || _bitcoinPaymentLinkExtension is null) return ("", "");
+        var bitcoinHandler = _handlers.TryGet(BitcoinOnchainPmi);
+        if (bitcoinHandler is null) return ("", "");
+
+        var pristineBitcoinUrl = _bitcoinPaymentLinkExtension.GetPaymentLink(bitcoinPrompt, realCtx.UrlHelper);
+        if (string.IsNullOrEmpty(pristineBitcoinUrl)) return ("", "");
+
+        // Synthetic model with PaymentMethodId == "BTC-CHAIN" so plugins that
+        // gate on that check (Branta) treat this as the bitcoin tab.
+        var synthetic = new CheckoutModel
+        {
+            PaymentMethodId = BitcoinOnchainPmi.ToString(),
+            PaymentMethodCurrency = realCtx.Model.PaymentMethodCurrency,
+            InvoiceBitcoinUrl = pristineBitcoinUrl,
+            InvoiceBitcoinUrlQR = pristineBitcoinUrl,
+        };
+        var syntheticCtx = realCtx with
+        {
+            Model = synthetic,
+            Prompt = bitcoinPrompt,
+            Handler = bitcoinHandler,
+        };
+
+        foreach (var global in _globalExtensions)
+        {
+            if (ReferenceEquals(global, this)) continue; // avoid recursion
+            try
+            {
+                global.ModifyCheckoutModel(syntheticCtx);
+            }
+            catch
+            {
+                // Best-effort. A misbehaving global shouldn't break the Arkade tab.
+            }
+        }
+
+        return (
+            DiffAddedQuery(pristineBitcoinUrl, synthetic.InvoiceBitcoinUrl),
+            DiffAddedQuery(pristineBitcoinUrl, synthetic.InvoiceBitcoinUrlQR));
     }
 
     void IGlobalCheckoutModelExtension.ModifyCheckoutModel(CheckoutModelContext context)
@@ -73,33 +163,66 @@ public class ArkadeCheckoutModelExtension: ICheckoutModelExtension, IGlobalCheck
     }
 
     /// <summary>
-    /// Uppercases address and parameter values for efficient QR alphanumeric encoding,
-    /// while keeping the scheme and parameter keys lowercase per BIP21 spec.
+    /// Uppercases only the address portion of the BIP21 URI for QR
+    /// alphanumeric-mode efficiency, mirroring what BTCPay itself does for
+    /// the bitcoin tab in <c>BitcoinCheckoutModelExtension</c>. Param values
+    /// are passed through verbatim — we have no protocol-agnostic way to
+    /// know whether a given value's payload is case-insensitive (bech32m,
+    /// decimal) or case-sensitive (URLs, base64, JWTs, future plugins'
+    /// data), so the safe default is to leave them alone.
     /// </summary>
     private static string UpperCaseQrUri(string bip21Uri)
     {
-        // Split into base (bitcoin:address) and query (?params)
         var qIdx = bip21Uri.IndexOf('?');
         if (qIdx < 0)
             return "bitcoin:" + bip21Uri["bitcoin:".Length..].ToUpperInvariant();
 
-        var basePart = bip21Uri[..qIdx];
-        var queryPart = bip21Uri[(qIdx + 1)..];
+        var address = bip21Uri["bitcoin:".Length..qIdx].ToUpperInvariant();
+        var queryPart = bip21Uri[qIdx..]; // includes leading '?'
+        return $"bitcoin:{address}{queryPart}";
+    }
 
-        // Uppercase the address
-        var address = basePart["bitcoin:".Length..].ToUpperInvariant();
+    /// <summary>
+    /// Returns the entries from <paramref name="after"/>'s query string whose
+    /// keys are absent from <paramref name="before"/>'s query string. Values
+    /// are returned verbatim (no decode/re-encode) so whatever URL-encoding
+    /// the contributing plugin chose round-trips byte-for-byte into our
+    /// final URL.
+    /// </summary>
+    private static string DiffAddedQuery(string before, string after)
+    {
+        if (string.IsNullOrEmpty(after) || ReferenceEquals(before, after)) return "";
 
-        // Uppercase parameter values but keep keys lowercase
-        var parameters = queryPart.Split('&')
-            .Select(p =>
-            {
-                var eqIdx = p.IndexOf('=');
-                if (eqIdx < 0) return p;
-                var key = p[..eqIdx].ToLowerInvariant();
-                var value = p[(eqIdx + 1)..].ToUpperInvariant();
-                return $"{key}={value}";
-            });
+        var beforeKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var entry in EnumerateQueryEntries(before))
+        {
+            var eq = entry.IndexOf('=');
+            beforeKeys.Add(eq < 0 ? entry : entry[..eq]);
+        }
 
-        return $"bitcoin:{address}?{string.Join("&", parameters)}";
+        var added = new List<string>();
+        foreach (var entry in EnumerateQueryEntries(after))
+        {
+            var eq = entry.IndexOf('=');
+            var key = eq < 0 ? entry : entry[..eq];
+            if (!beforeKeys.Contains(key))
+                added.Add(entry);
+        }
+        return string.Join("&", added);
+    }
+
+    private static IEnumerable<string> EnumerateQueryEntries(string url)
+    {
+        if (string.IsNullOrEmpty(url)) return [];
+        var qIdx = url.IndexOf('?');
+        if (qIdx < 0) return [];
+        return url[(qIdx + 1)..].Split('&', StringSplitOptions.RemoveEmptyEntries);
+    }
+
+    private static string AppendQuery(string url, string entries)
+    {
+        if (string.IsNullOrEmpty(entries)) return url;
+        var sep = url.Contains('?') ? "&" : "?";
+        return url + sep + entries;
     }
 }

--- a/BTCPayServer.Plugins.ArkPayServer/PaymentHandler/ArkadePaymentLinkExtension.cs
+++ b/BTCPayServer.Plugins.ArkPayServer/PaymentHandler/ArkadePaymentLinkExtension.cs
@@ -29,16 +29,31 @@ public class ArkadePaymentLinkExtension : IPaymentLinkExtension
         var lnurl = prompt.ParentEntity.GetPaymentPrompt(PaymentTypes.LNURL.GetPaymentMethodId("BTC"));
 
         var amount = prompt.Calculate().Due;
-        
+
         // Build BIP21 URI using the helper
         var builder = ArkadeBip21Builder.Create()
             .WithArkAddress(prompt.Destination)
             .WithAmount(amount);
-        
-        // Add onchain address if available, otherwise use boarding address
+
+        // Add onchain address if available, otherwise use boarding address.
+        // When an onchain payment method is present, also delegate to its own
+        // IPaymentLinkExtension so any params other plugins attached to the
+        // upstream BIP21 (PayJoin's `pj=`, Branta's `branta_*`, etc.) carry
+        // through to the unified Arkade QR. Without this the Arkade tab
+        // clobbers those params (issue: Branta + PayJoin lose their hooks).
         if (!string.IsNullOrEmpty(onchain?.Destination))
         {
             builder.WithOnchainAddress(onchain.Destination);
+
+            var onchainLink = _serviceProvider.GetServices<IPaymentLinkExtension>()
+                .FirstOrDefault(p => p.PaymentMethodId == onchain.PaymentMethodId);
+            if (onchainLink is not null)
+            {
+                var upstream = onchainLink.GetPaymentLink(onchain, urlHelper);
+                var qIdx = upstream?.IndexOf('?') ?? -1;
+                if (qIdx >= 0)
+                    builder.WithExtraQuery(upstream![(qIdx + 1)..]);
+            }
         }
         else if (prompt.Details is not null)
         {


### PR DESCRIPTION
## Summary

Reported by Keith / Branta team: when the Arkade tab is open on a BTCPay checkout, BIP21 params that other plugins attached to the bitcoin onchain URL — PayJoin's \`pj=\`, Branta's \`branta_id\` / \`branta_secret\`, etc. — were being silently dropped. The Arkade builder rebuilt the URI from scratch with only the bare bech32 address.

There are two layers in BTCPay where plugins contribute URL params, and we now harvest both:

| Layer | Used by | Fix |
|---|---|---|
| \`IPaymentLinkExtension.GetPaymentLink()\` | PayJoin (built-in BTCPay) | \`ArkadePaymentLinkExtension\` resolves the bitcoin onchain extension and forwards every \`key=value\` entry verbatim into a new \`ArkadeBip21Builder.WithExtraQuery\` (skipping \`amount\` / \`ark\` / \`lightning\` which we own). |
| \`IGlobalCheckoutModelExtension.ModifyCheckoutModel()\` | Branta (per [\`SetZeroKnowledgeParams\`](https://github.com/BrantaOps/btcpay/blob/main/BTCPayServer.Plugins.Branta/Classes/Helper.cs)) | \`ArkadeCheckoutModelExtension\` synthesises a bitcoin-tab \`CheckoutModelContext\`, runs every other global extension on it (skipping itself), diffs the resulting URLs against the pristine bitcoin BIP21, and merges the new entries onto the Arkade URLs. |

Also: \`UpperCaseQrUri\` only uppercases values for case-insensitive keys (\`ark\`, \`lightning\`, \`amount\`) — uppercasing PayJoin's onion URL or Branta's base64 \`branta_secret\` would corrupt them.

## Trade-off (documented in code)

The synthetic-pipeline approach replays other plugins' \`IGlobalCheckoutModelExtension\` work on a manufactured context. Plugins doing only URL mutation (Branta) are safe; any plugin doing DB writes / metrics / cache work in its global hook would see those side effects fire a second time per checkout-page render. We accept this for the UX win; the right long-term fix is for Branta-style plugins to also recognise the Arkade payment method ID in their gate.

## Test plan

- [ ] CI build passes
- [ ] Manual: invoice rendered with PayJoin enabled — Arkade tab QR has \`pj=\`
- [ ] Manual: invoice rendered with Branta plugin installed — Arkade tab QR has \`branta_id\` and \`branta_secret\`
- [ ] Manual: bitcoin tab QR is unaffected (no double-application of params)
- [ ] Manual: Arkade tab QR's address + \`ark=\` / \`lightning=\` values are still uppercased; \`pj=\` and \`branta_*\` values pass through with original case preserved