### PR TITLE
chore(sdk): bump NNark to a89d47a — migrate to unified IBitcoinBlockchain

### DIFF
--- a/BTCPayServer.Plugins.ArkPayServer/ArkPlugin.cs
+++ b/BTCPayServer.Plugins.ArkPayServer/ArkPlugin.cs
@@ -18,8 +18,7 @@ using Microsoft.Extensions.Logging;
 using NArk.Abstractions.Blockchain;
 using NArk.Abstractions.Intents;
 using NArk.Abstractions.Safety;
-using NArk.Abstractions.Services;
-using NArk.Blockchain.NBXplorer;
+using NArk.Blockchain;
 using NArk.Hosting;
 using NArk.Core.Models.Options;
 using NArk.Core.Services;
@@ -129,17 +128,18 @@ public class ArkadePlugin : BaseBTCPayServerPlugin
         // Safety service
         services.AddSingleton<ISafetyService, NArk.Safety.AsyncKeyedLock.AsyncSafetyService>();
 
-        // Chain time provider (needs NBXplorer)
-        services.AddSingleton<ChainTimeProvider>(provider =>
+        // Unified blockchain backend (chain time + boarding-UTXO lookup +
+        // broadcast + tx status + fee estimation). Pass the inner provider's
+        // logger so the cache-fallback warning (emitted when Bitcoin Core
+        // RPC blips and we serve a stale chain time) is visible in plugin
+        // logs rather than swallowed.
+        services.AddSingleton<NBXplorerBlockchain>(provider =>
         {
             var explorerClientProvider = provider.GetRequiredService<ExplorerClientProvider>();
-            // Pass the inner provider's logger so the cache-fallback warning
-            // (emitted when Bitcoin Core RPC blips and we serve a stale
-            // chain time) is visible in plugin logs rather than swallowed.
-            var logger = provider.GetService<Microsoft.Extensions.Logging.ILogger<NArk.Blockchain.NBXplorer.RPCChainTimeProvider>>();
-            return new ChainTimeProvider(explorerClientProvider.GetExplorerClient("BTC"), logger);
+            var logger = provider.GetService<ILogger<NBXplorerBlockchain>>();
+            return new NBXplorerBlockchain(explorerClientProvider.GetExplorerClient("BTC"), logger);
         });
-        services.AddSingleton<IChainTimeProvider>(sp => sp.GetRequiredService<ChainTimeProvider>());
+        services.AddSingleton<IBitcoinBlockchain>(sp => sp.GetRequiredService<NBXplorerBlockchain>());
 
         // Intent scheduler
         services.Configure<SimpleIntentSchedulerOptions>(options =>
@@ -149,12 +149,8 @@ public class ArkadePlugin : BaseBTCPayServerPlugin
         // Wallet provider
         services.AddSingleton<NArk.Abstractions.Wallets.IWalletProvider, NArk.Core.Wallet.DefaultWalletProvider>();
 
-        // Boarding UTXO detection via NBXplorer
-        services.AddSingleton<IBoardingUtxoProvider>(provider =>
-        {
-            var explorerClient = provider.GetRequiredService<ExplorerClientProvider>().GetExplorerClient("BTC");
-            return new NBXplorerBoardingUtxoProvider(explorerClient);
-        });
+        // BoardingUtxoSyncService consumes IBitcoinBlockchain.GetUtxosAsync — the
+        // NBXplorer-backed registration above implements it for boarding lookup.
         services.AddSingleton<BoardingUtxoSyncService>();
 
         // Core services and network config (includes caching transport by default)

--- a/BTCPayServer.Plugins.ArkPayServer/Controllers/ArkController.cs
+++ b/BTCPayServer.Plugins.ArkPayServer/Controllers/ArkController.cs
@@ -74,7 +74,7 @@ public class ArkController(
     ISpendingService arkadeSpender,
     IFeeEstimator feeEstimator,
     IContractService contractService,
-    IChainTimeProvider bitcoinTimeChainProvider,
+    IBitcoinBlockchain bitcoinTimeChainProvider,
     VtxoSynchronizationService vtxoSyncService,
     IContractStorage contractStorage,
     ISwapStorage swapStorage,

--- a/BTCPayServer.Plugins.ArkPayServer/Lightning/ArkLightningClient.cs
+++ b/BTCPayServer.Plugins.ArkPayServer/Lightning/ArkLightningClient.cs
@@ -25,7 +25,7 @@ public class ArkLightningClient(
     ISwapStorage swapStorage,
     IContractStorage contractStorage,
     ISpendingService spendingService,
-    IChainTimeProvider chainTimeProvider,
+    IBitcoinBlockchain chainTimeProvider,
     ILogger<ArkLightningInvoiceListener> logger) : IExtendedLightningClient
 {
     /// <summary>

--- a/BTCPayServer.Plugins.ArkPayServer/Views/Ark/Contracts.cshtml
+++ b/BTCPayServer.Plugins.ArkPayServer/Views/Ark/Contracts.cshtml
@@ -16,7 +16,7 @@
 @inject IScopeProvider ScopeProvider
 @inject IClientTransport ClientTransport
 @inject ArkNetworkConfig ArkNetworkConfig
-@inject IChainTimeProvider ChainTimeProvider
+@inject IBitcoinBlockchain ChainTimeProvider
 @inject TransactionLinkProviders TransactionLinkProviders
 @{
     Layout = "_Layout";

--- a/BTCPayServer.Plugins.ArkPayServer/Views/Ark/Vtxos.cshtml
+++ b/BTCPayServer.Plugins.ArkPayServer/Views/Ark/Vtxos.cshtml
@@ -12,7 +12,7 @@
 @model BTCPayServer.Plugins.ArkPayServer.Models.StoreVtxosViewModel
 @inject IScopeProvider ScopeProvider
 @inject ArkNetworkConfig ArkNetworkConfig
-@inject IChainTimeProvider ChainTimeProvider
+@inject IBitcoinBlockchain ChainTimeProvider
 @inject IClientTransport ClientTransport
 @inject TransactionLinkProviders TransactionLinkProviders
 

--- a/BTCPayServer.Plugins.ArkPayServer/Views/Shared/_VtxoTable.cshtml
+++ b/BTCPayServer.Plugins.ArkPayServer/Views/Shared/_VtxoTable.cshtml
@@ -7,7 +7,7 @@
 @using NBitcoin
 @using NArk.Abstractions.VTXOs
 @inject ArkNetworkConfig ArkNetworkConfig
-@inject IChainTimeProvider ChainTimeProvider
+@inject IBitcoinBlockchain ChainTimeProvider
 @inject IClientTransport ClientTransport
 @model IEnumerable<ArkVtxo>
 

--- a/NArk.E2E.Tests/NArk.E2E.Tests.csproj
+++ b/NArk.E2E.Tests/NArk.E2E.Tests.csproj
@@ -14,8 +14,8 @@
     <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="NBitcoin" Version="9.0.4" />
-    <PackageReference Include="Grpc.Net.Client" Version="2.67.0" />
+    <PackageReference Include="NBitcoin" Version="10.0.1" />
+    <PackageReference Include="Grpc.Net.Client" Version="2.76.0" />
     <PackageReference Include="CliWrap" Version="3.6.6" />
     <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Summary
- Bumps `submodules/NNark` from `e024b16` to `a89d47a` (master) — picks up unilateral-exit support (#39), Boltz multi-provider arch (#79), payment-tracking improvements (#75), EFCore SQLite ORDER BY fix (#92), recovery reconciliation (#90).
- Migrates the plugin to the unified `IBitcoinBlockchain` interface that replaced `IBoardingUtxoProvider` + `IChainTimeProvider` + `IOnchainBroadcaster` in NNark PR #39.
- Bumps `NArk.E2E.Tests` package refs to match the new transitive minimums from NNark (`NBitcoin` 9.0.4→10.0.1, `Grpc.Net.Client` 2.67.0→2.76.0).

## Plugin changes
- `ArkPlugin.cs` — DI: `NBXplorerBlockchain` registered once and exposed as `IBitcoinBlockchain` (last-wins). Replaces the prior separate `ChainTimeProvider` + `NBXplorerBoardingUtxoProvider` registrations. `BoardingUtxoSyncService` now consumes `IBitcoinBlockchain.GetUtxosAsync` for boarding lookup.
- `ArkController.cs`, `ArkLightningClient.cs` — ctor param `IChainTimeProvider` → `IBitcoinBlockchain`. Call sites unchanged (`.GetChainTime(...)` is on the new interface).
- 3 Razor views (`Shared/_VtxoTable.cshtml`, `Ark/Vtxos.cshtml`, `Ark/Contracts.cshtml`) — `@inject IChainTimeProvider` → `@inject IBitcoinBlockchain`.

## Test plan
- [x] `dotnet build NArk.sln` — 0 errors
- [ ] Run the plugin in BTCPay locally, exercise: store dashboard → Ark VTXOs/Contracts views render (chain-time still surfaced); send/receive on a regtest store; LN invoice via `ArkLightningClient`.
- [ ] CI green.

## Out of scope
- No version bump in `BTCPayServer.Plugins.ArkPayServer.csproj` — landed as `chore` since the public plugin surface didn't change. Bump in a follow-up PR with a CHANGELOG entry if a release is desired.