### PR TITLE
fix(receive): demote 'New X' refresh buttons to text buttons

### DIFF
--- a/BTCPayServer.Plugins.ArkPayServer/Views/Ark/Receive.cshtml
+++ b/BTCPayServer.Plugins.ArkPayServer/Views/Ark/Receive.cshtml
@@ -128,11 +128,16 @@
             </div>
         </div>
         <div class="payment-box">
-            <div class="mt-4 d-flex gap-2">
-                <button type="submit" name="command" value="generate-address" class="btn btn-primary flex-grow-1">
+            <div class="mt-4 d-flex gap-2 justify-content-center align-items-center">
+                @* "New X" is a refresh action once the address already exists, so a
+                   quiet text button is the right visual weight; "Generate X" stays
+                   a prominent CTA when that address is still missing. *@
+                <button type="submit" name="command" value="generate-address"
+                        class="btn @(hasAddress ? "btn-link" : "btn-primary flex-grow-1")">
                     @(hasAddress ? "New Ark address" : "Generate Ark address")
                 </button>
-                <button type="submit" name="command" value="generate-boarding-address" class="btn btn-outline-primary flex-grow-1">
+                <button type="submit" name="command" value="generate-boarding-address"
+                        class="btn @(hasBoarding ? "btn-link" : "btn-outline-primary flex-grow-1")">
                     @(hasBoarding ? "New boarding address" : "Generate boarding address")
                 </button>
             </div>


### PR DESCRIPTION
## Receive: demote "New X" refresh buttons to text buttons

Once an address has been generated, the corresponding "New X" button is a refresh action, not a primary CTA. The current full-width `btn-primary` / `btn-outline-primary` gives it the same visual weight as the QR/address shown above — too loud for "generate me another one of the same kind."

Change: when the address for that button already exists (label = "New X"), render it as `btn-link` (a quiet text button); when it doesn't exist yet (label = "Generate X"), keep the prominent button — it's still a real CTA for adding the missing address type.

The flex wrapper picks up `justify-content-center` + `align-items-center` so the two states (one prominent + one text, both text, or both prominent) all sit comfortably on one row.

No other changes — same form, same `command` values, same controller wiring.
