### PR TITLE
test(e2e): re-poll suggest-coins right before build-intent (stop master flake)

### DIFF
--- a/NArk.E2E.Tests/FundedWalletTests.cs
+++ b/NArk.E2E.Tests/FundedWalletTests.cs
@@ -88,6 +88,17 @@ public class FundedWalletTests : PlaywrightBaseTest
         Assert.True(hasFee, $"estimate-fees response missing a fee field: {feeJson}");
 
         // 2) Send 40k to the recipient via build-intent (uses one VTXO).
+        // Re-poll right before the POST: between the earlier poll and now
+        // we've created another store, browsed pages, and run estimate-fees
+        // — enough wall-clock that a batch settlement or VTXO state change
+        // can invalidate the originally captured outpoints. suggest-coins
+        // and build-intent occasionally disagree across that window
+        // ("No valid VTXOs selected" from build-intent's stricter check),
+        // so refresh outpoints to the live set just before submitting.
+        outpoints = await PollForSpendableCoinsAsync(
+            storeId, "ArkAddress", 40_000, TimeSpan.FromMinutes(1));
+        Assert.NotEmpty(outpoints);
+
         await GoToUrl($"/plugins/ark/stores/{storeId}/overview");
         token = (await GetAntiforgeryTokenAsync()) ?? "";
         var sendResp = await Page.Context.APIRequest.PostAsync(


### PR DESCRIPTION
## Stop `FundedWallet_FullJourney_FundEstimateSendPayout` from flaking master on every push

### Symptom
`E2E` on master has gone red on the last three pushes (`79ef7b9` #57 README, `016a92b` #58 Receive view, `07d7e59` #59 text-button) — none of which touch coin-selection code. PR-branch E2E was green for each before merge. Same test fails each time:

```
Failed FundedWallet_FullJourney_FundEstimateSendPayout [5 s]
   Assert.DoesNotContain() Failure: Sub-string found
String: ···"<li>No valid VTXOs select"···
Found:  "No valid VTXOs selected"
   at NArk.E2E.Tests.FundedWalletTests.FundedWallet_FullJourney_FundEstimateSendPayout()
     in NArk.E2E.Tests/FundedWalletTests.cs:line 109
```

### Diagnosis
TOCTOU between `PollForSpendableCoinsAsync` (line 56) and the `build-intent` POST (line 109). Between those two points the test:
- Creates a recipient store + fresh wallet.
- Browses overview pages.
- Issues a token-fetch and an `estimate-fees` POST.

That's enough wall-clock for a batch settlement (or any VTXO state shift) to invalidate the originally captured outpoints. `build-intent`'s stricter coin validation then surfaces "No valid VTXOs selected" — the early poll's outpoints are stale.

### Fix
Re-poll `suggest-coins` immediately before the `build-intent` POST and use the refreshed outpoints. 1-minute timeout (state should already be stable; if not, the existing helper's diagnostic message bubbles up).

Pure test-resilience change — **no product code touched**. Successful runs add ~one poll cycle (~3 s); previously-flaky runs converge to stable outpoints before submitting.

### Test plan
- [x] Single, surgical edit (`NArk.E2E.Tests/FundedWalletTests.cs`).
- [ ] CI: `build` + `E2E` green on this branch.
- [ ] Master `E2E` green on the next push after merge.
