### PR TITLE
fix(receive): vertical-stack 'New X' refresh buttons + 'Receive Arkade' title

### DIFF
--- a/BTCPayServer.Plugins.ArkPayServer/Views/Ark/Receive.cshtml
+++ b/BTCPayServer.Plugins.ArkPayServer/Views/Ark/Receive.cshtml
@@ -41,7 +41,7 @@
             <button class="btn btn-outline-primary w-100" type="submit" name="command" value="generate-boarding-address">
                 Generate boarding address
             </button>
-            <p class="text-muted small text-center mt-2 mb-0">Onchain Bitcoin deposit into Ark</p>
+            <p class="text-muted small text-center mt-2 mb-0">Onchain Bitcoin deposit into Arkade</p>
         </div>
     }
     else
@@ -49,7 +49,7 @@
         // Single source of truth for BIP-21 — same shape the checkout uses
         // (bitcoin:<boarding>?ark=<arkAddress>): wallets that only speak
         // standard BIP-21 see the boarding address as the payable target;
-        // Ark-aware wallets pick up the ark= param too.
+        // Arkade-aware wallets pick up the ark= param too.
         string? paymentLink = null;
         if (hasAddress)
         {
@@ -94,7 +94,7 @@
                         <div class="input-group mt-3">
                             <div class="form-floating">
                                 <vc:truncate-center text="@Model.Address" padding="15" elastic="true" classes="form-control-plaintext" id="Address" />
-                                <label for="Address">Ark Address</label>
+                                <label for="Address">Arkade Address</label>
                             </div>
                         </div>
                     </div>
@@ -122,7 +122,7 @@
                                 <label for="BoardingAddress">Boarding Address (Onchain)</label>
                             </div>
                         </div>
-                        <p class="text-muted small mt-2 mb-0">Send onchain BTC to board into Ark. Requires 1 confirmation + batch round.</p>
+                        <p class="text-muted small mt-2 mb-0">Send onchain BTC to board into Arkade. Requires 1 confirmation + batch round.</p>
                     </div>
                 }
             </div>
@@ -134,7 +134,7 @@
                vertically with minimal padding so each label fits on one line. *@
             <button type="submit" name="command" value="generate-address"
                     class="btn @(hasAddress ? "btn-link py-1" : "btn-primary")">
-                @(hasAddress ? "New Ark address" : "Generate Ark address")
+                @(hasAddress ? "New Arkade address" : "Generate Arkade address")
             </button>
             <button type="submit" name="command" value="generate-boarding-address"
                     class="btn @(hasBoarding ? "btn-link py-1" : "btn-outline-primary")">

--- a/BTCPayServer.Plugins.ArkPayServer/Views/Ark/Receive.cshtml
+++ b/BTCPayServer.Plugins.ArkPayServer/Views/Ark/Receive.cshtml
@@ -8,7 +8,7 @@
     var storeId = ScopeProvider.GetCurrentStoreId();
     var returnUrl = Url.Action("StoreOverview", "Ark", new { storeId });
     Layout = "_LayoutWizard";
-    ViewData.SetTitle("Receive ARK");
+    ViewData.SetTitle("Receive Arkade");
     var hasAddress = !string.IsNullOrEmpty(Model.Address);
     var hasBoarding = !string.IsNullOrEmpty(Model.BoardingAddress);
     var hasAny = hasAddress || hasBoarding;
@@ -127,20 +127,19 @@
                 }
             </div>
         </div>
-        <div class="payment-box">
-            <div class="mt-4 d-flex gap-2 justify-content-center align-items-center">
-                @* "New X" is a refresh action once the address already exists, so a
-                   quiet text button is the right visual weight; "Generate X" stays
-                   a prominent CTA when that address is still missing. *@
-                <button type="submit" name="command" value="generate-address"
-                        class="btn @(hasAddress ? "btn-link" : "btn-primary flex-grow-1")">
-                    @(hasAddress ? "New Ark address" : "Generate Ark address")
-                </button>
-                <button type="submit" name="command" value="generate-boarding-address"
-                        class="btn @(hasBoarding ? "btn-link" : "btn-outline-primary flex-grow-1")">
-                    @(hasBoarding ? "New boarding address" : "Generate boarding address")
-                </button>
-            </div>
+        <div class="mt-2 d-flex flex-column align-items-center">
+            @* "New X" is a refresh action once the address already exists, so a
+               quiet text button is the right visual weight; "Generate X" stays
+               a prominent CTA when that address is still missing. Stacked
+               vertically with minimal padding so each label fits on one line. *@
+            <button type="submit" name="command" value="generate-address"
+                    class="btn @(hasAddress ? "btn-link py-1" : "btn-primary")">
+                @(hasAddress ? "New Ark address" : "Generate Ark address")
+            </button>
+            <button type="submit" name="command" value="generate-boarding-address"
+                    class="btn @(hasBoarding ? "btn-link py-1" : "btn-outline-primary")">
+                @(hasBoarding ? "New boarding address" : "Generate boarding address")
+            </button>
         </div>
         <p class="text-muted small text-center mt-3 mb-0">Addresses auto-deactivate once funds arrive</p>
     }


### PR DESCRIPTION
## Receive: stack "New X" refresh buttons vertically + Arkade in the title

Two small polish fixes on the Receive page, both visible:

1. **Vertical-stack the "New X" text buttons.** Side-by-side in a `payment-box`, the row was tall and each label wrapped onto two lines ("New Ark / address"). Now `d-flex flex-column align-items-center`, `mt-2` instead of `mt-4`, `py-1` on the btn-link variants, dropped the `payment-box` wrapper and `flex-grow-1` (irrelevant vertically). Each label sits on one line; the refresh row no longer dominates the payment-link panel above it. The unmet-state "Generate X" buttons keep their prominent `btn-primary` / `btn-outline-primary` styling.
2. **Page title `Receive ARK` → `Receive Arkade`.** Per the brand rule (user-facing text is "Arkade"; code identifiers like the `Ark` controller name stay).

Broader user-facing `Ark` → `Arkade` sweep across other views (`InitialSetup`, `IntentBuilder`, `Contracts`, `ConfigurePayoutProcessor`) and controller messages follows in a separate PR — out of scope for this Receive-page polish.

### Before / after
- Before: two narrow text buttons side-by-side, each wrapping; `payment-box` padding inflating the row height.
- After: vertical stack, full label per line, tighter spacing under the QR/link panel.
