### PR TITLE
fix(branding): use 'Arkade' (not bare 'Ark') in user-facing text

### DIFF
--- a/BTCPayServer.Plugins.ArkPayServer/Controllers/ArkController.cs
+++ b/BTCPayServer.Plugins.ArkPayServer/Controllers/ArkController.cs
@@ -231,7 +231,7 @@ public class ArkController(
                 });
             }
 
-            TempData[WellKnownTempData.SuccessMessage] = "Ark Payment method updated.";
+            TempData[WellKnownTempData.SuccessMessage] = "Arkade payment method updated.";
 
             return RedirectToAction(nameof(StoreOverview), new { storeId });
         }
@@ -1095,7 +1095,7 @@ public class ArkController(
             {
                 var estimatedFee = await feeEstimator.EstimateFeeAsync(coins.ToArray(), outputs.ToArray(), token);
                 response.EstimatedFeeSats = estimatedFee;
-                response.FeeDescription = hasOnchain ? "Batch transaction fee" : "Ark service fee";
+                response.FeeDescription = hasOnchain ? "Batch transaction fee" : "Arkade service fee";
             }
 
             return Json(response);
@@ -2487,7 +2487,7 @@ public class ArkController(
             await walletStorage.DeleteWallet(walletId, HttpContext.RequestAborted);
         }
 
-        return RedirectWithSuccess(nameof(InitialSetup), "Ark wallet configuration cleared.", new { storeId });
+        return RedirectWithSuccess(nameof(InitialSetup), "Arkade wallet configuration cleared.", new { storeId });
     }
 
     [HttpPost("stores/{storeId}/force-refresh")]
@@ -2772,7 +2772,7 @@ public class ArkController(
             return !serverKey.ToBytes().SequenceEqual(addr!.ServerKey.ToBytes()) ? throw new Exception("Invalid destination address") : new TemporaryWalletSettings(GenerateWallet(), null, wallet, true, true);
         }
         var existingWallet = await walletStorage.GetWalletById(wallet, HttpContext.RequestAborted);
-        return existingWallet == null ? throw new Exception("Unsupported value. Enter a BIP-39 seed phrase (12 or 24 words), nsec private key, Ark address, or wallet ID.") : new TemporaryWalletSettings(null, wallet, null, false, false);
+        return existingWallet == null ? throw new Exception("Unsupported value. Enter a BIP-39 seed phrase (12 or 24 words), nsec private key, Arkade address, or wallet ID.") : new TemporaryWalletSettings(null, wallet, null, false, false);
     }
     private static string GenerateWallet()
     {
@@ -3157,7 +3157,7 @@ public class ArkController(
         try
         {
             var limits = await boltzLimitsValidator.GetAllLimitsAsync(cancellationToken);
-            return (limits != null, limits == null ? "Boltz instance does not support Ark" : null, limits);
+            return (limits != null, limits == null ? "Boltz instance does not support Arkade" : null, limits);
         }
         catch (Exception ex)
         {
@@ -3828,7 +3828,7 @@ public class ArkController(
             result.AmountSats = amountSats;
             result.IsValid = true;
             if (amountSats <= 0)
-                result.Error = "Amount is required for Ark address";
+                result.Error = "Amount is required for Arkade address";
             return result;
         }
 
@@ -3920,7 +3920,7 @@ public class ArkController(
             }
 
             // Bitcoin address without ark/lightning is not supported in Send2 (offchain only)
-            result.Error = "BIP21 URI does not contain an Ark address or Lightning invoice. Send2 only supports offchain transfers.";
+            result.Error = "BIP21 URI does not contain an Arkade address or Lightning invoice. Send2 only supports offchain transfers.";
             return result;
         }
 
@@ -3933,7 +3933,7 @@ public class ArkController(
             return result;
         }
 
-        result.Error = "Unrecognized destination format. Use an Ark address, Lightning invoice, or BIP21 URI with ark/lightning parameter.";
+        result.Error = "Unrecognized destination format. Use an Arkade address, Lightning invoice, or BIP21 URI with ark/lightning parameter.";
         return result;
     }
 
@@ -3961,7 +3961,7 @@ public class ArkController(
                     {
                         var fee = await feeEstimator.EstimateFeeAsync(spendableCoins, outputs, token);
                         dest.FeeSats = fee;
-                        dest.FeeDescription = "Ark service fee";
+                        dest.FeeDescription = "Arkade service fee";
                     }
                 }
                 else if (dest.Type is Send2DestinationType.LightningInvoice or Send2DestinationType.Bip21Lightning or Send2DestinationType.Lnurl)

--- a/BTCPayServer.Plugins.ArkPayServer/Views/Ark/ConfigurePayoutProcessor.cshtml
+++ b/BTCPayServer.Plugins.ArkPayServer/Views/Ark/ConfigurePayoutProcessor.cshtml
@@ -6,7 +6,7 @@
 @{
     Layout = "_Layout";
     var storeId = Context.GetStoreData().Id;
-    ViewData.SetActivePage(StoreNavPages.PayoutProcessors, "Ark Payout Processor", storeId);
+    ViewData.SetActivePage(StoreNavPages.PayoutProcessors, "Arkade Payout Processor", storeId);
 }
 
 <form method="post" permissioned="@Policies.CanModifyStoreSettings" data-testid="payout-processor-form">
@@ -25,7 +25,7 @@
     <partial name="_StatusMessage" />
     <div class="row">
         <div class="col-xl-8 col-xxl-constrain">
-            <p text-translate="true">Set a schedule for automated Ark Network Payouts.</p>
+            <p text-translate="true">Set a schedule for automated Arkade Network Payouts.</p>
             @if (!ViewContext.ModelState.IsValid)
             {
                 <div asp-validation-summary="All"></div>

--- a/BTCPayServer.Plugins.ArkPayServer/Views/Ark/Contracts.cshtml
+++ b/BTCPayServer.Plugins.ArkPayServer/Views/Ark/Contracts.cshtml
@@ -20,7 +20,7 @@
 @inject TransactionLinkProviders TransactionLinkProviders
 @{
     Layout = "_Layout";
-    ViewData.SetActivePage(category: "Ark", activePage: "Contracts", title: "Ark - Contracts");
+    ViewData.SetActivePage(category: "Ark", activePage: "Contracts", title: "Arkade - Contracts");
     var storeId = ScopeProvider.GetCurrentStoreId();
     var mainnet = true;
     var chainTime = await ChainTimeProvider.GetChainTime(Context.RequestAborted);
@@ -64,7 +64,7 @@
 <div id="descriptor" class="collapse">
     <div class="d-flex px-4 py-4 mb-4 bg-tile rounded">
         <div class="flex-fill">
-            <p text-translate="true" class="mb-2">Contracts are Ark payment addresses that can receive VTXOs.</p>
+            <p text-translate="true" class="mb-2">Contracts are Arkade payment addresses that can receive VTXOs.</p>
             <p text-translate="true" class="mb-3">Each contract represents a unique payment destination secured by your wallet.</p>
         </div>
         <button type="button" class="btn-close ms-auto" data-bs-toggle="collapse" data-bs-target="#descriptor" aria-expanded="false" aria-label="Close">
@@ -324,7 +324,7 @@
                             <td class="align-middle text-end">
                                 <div class="d-inline-flex align-items-center gap-2">
                                     <button type="button" class="btn btn-link p-0 text-secondary sync-contract-btn"
-                                            title="Refresh contract data from the Ark operator"
+                                            title="Refresh contract data from the Arkade operator"
                                             data-bs-toggle="tooltip"
                                             data-script="@contract.Script">
                                         <vc:icon symbol="actions-refresh" />
@@ -449,7 +449,7 @@ else
                 <form asp-action="ImportContract" method="post" asp-route-storeId="@Model.StoreId">
                     <div class="modal-body">
                         <div class="alert alert-info">
-                            <strong>Info:</strong> Import an existing Ark contract to track its VTXOs and swaps.
+                            <strong>Info:</strong> Import an existing Arkade contract to track its VTXOs and swaps.
                         </div>
                         <div class="form-group mb-3">
                             <label class="form-label">Contract String</label>
@@ -464,7 +464,7 @@ else
                             <strong>Note:</strong> Make sure you have the private key for this contract to spend its VTXOs.
                         </div>
                         <p class="text-muted mb-0">
-                            The contract will be added to your wallet and synced with the Ark operator to detect any existing VTXOs.
+                            The contract will be added to your wallet and synced with the Arkade operator to detect any existing VTXOs.
                         </p>
                     </div>
                     <div class="modal-footer">

--- a/BTCPayServer.Plugins.ArkPayServer/Views/Ark/InitialSetup.cshtml
+++ b/BTCPayServer.Plugins.ArkPayServer/Views/Ark/InitialSetup.cshtml
@@ -5,7 +5,7 @@
 
 @{
     Layout = "_LayoutWizard";
-    ViewData.SetActivePage(category: "Ark", activePage: "initialSetup", title: "Ark - Getting Started");
+    ViewData.SetActivePage(category: "Ark", activePage: "initialSetup", title: "Arkade - Getting Started");
     var storeId = ScopeProvider.GetCurrentStoreId();
     var hasValidationError = !ViewData.ModelState.IsValid;
     var hasWalletValue = !string.IsNullOrEmpty(Model.Wallet);
@@ -20,8 +20,8 @@
 }
 
 <header class="text-center">
-    <h1>Setup Your Ark Wallet</h1>
-    <p class="lead text-secondary mt-3">Choose how you want to configure your Ark wallet</p>
+    <h1>Setup Your Arkade Wallet</h1>
+    <p class="lead text-secondary mt-3">Choose how you want to configure your Arkade wallet</p>
 </header>
 
 <div class="mt-5">
@@ -33,7 +33,7 @@
             </div>
             <div class="content">
                 <h4>Use an existing wallet</h4>
-                <p class="mb-0 text-secondary">Import from private key, Ark address, or existing wallet ID</p>
+                <p class="mb-0 text-secondary">Import from private key, Arkade address, or existing wallet ID</p>
             </div>
             <vc:icon symbol="caret-right" />
         </a>
@@ -52,7 +52,7 @@
                             <ul class="mb-0">
                                 <li><strong>BIP-39 seed phrase:</strong> Import an HD wallet from 12 or 24-word mnemonic (recommended)</li>
                                 <li><strong>nsec private key:</strong> Use a legacy Nostr-style private key as a hot wallet</li>
-                                <li><strong>Ark address (npub):</strong> Create a transitory wallet that auto-sweeps to this address</li>
+                                <li><strong>Arkade address (npub):</strong> Create a transitory wallet that auto-sweeps to this address</li>
                                 <li><strong>Wallet ID:</strong> Use an existing wallet from this BTCPay instance</li>
                             </ul>
                         </div>
@@ -87,7 +87,7 @@
                     <div class="alert alert-info">
                         <strong>Info:</strong> A new hot wallet will be generated automatically for you.
                     </div>
-                    <p>This will create a new Ark wallet that is stored on your BTCPay Server. Make sure to back up your wallet after creation.</p>
+                    <p>This will create a new Arkade wallet that is stored on your BTCPay Server. Make sure to back up your wallet after creation.</p>
                     <button name="command" type="submit" value="save" class="btn btn-primary" data-testid="create-wallet-btn">Create Wallet</button>
                 </form>
             </div>

--- a/BTCPayServer.Plugins.ArkPayServer/Views/Ark/IntentBuilder.cshtml
+++ b/BTCPayServer.Plugins.ArkPayServer/Views/Ark/IntentBuilder.cshtml
@@ -6,7 +6,7 @@
 
 @{
     Layout = "_Layout";
-    var pageTitle = "Ark - Join Batch";
+    var pageTitle = "Arkade - Join Batch";
     ViewData.SetActivePage(category: "Ark", activePage: "IntentBuilder", title: pageTitle);
     var storeId = ScopeProvider.GetCurrentStoreId()!;
 }
@@ -30,9 +30,9 @@
 <div id="descriptor" class="collapse">
     <div class="d-flex px-4 py-4 mb-4 bg-tile rounded">
         <div class="flex-fill">
-            <p text-translate="true" class="mb-2">Join the next Ark batch to consolidate or transfer your VTXOs.</p>
+            <p text-translate="true" class="mb-2">Join the next Arkade batch to consolidate or transfer your VTXOs.</p>
             <p text-translate="true" class="mb-3">
-                Leave destination empty to consolidate to self, or specify an <strong>Ark address</strong> for offchain transfer,
+                Leave destination empty to consolidate to self, or specify an <strong>Arkade address</strong> for offchain transfer,
                 <strong>Bitcoin address</strong> for onchain output, or <strong>Lightning invoice</strong> for instant payment.
             </p>
         </div>
@@ -172,9 +172,9 @@
                                                    name="Outputs[@i].Destination"
                                                    value="@output.Destination"
                                                    class="form-control destination-input"
-                                                   placeholder="Ark address, BIP21 URI, or Lightning invoice (leave empty to consolidate to self)..." />
+                                                   placeholder="Arkade address, BIP21 URI, or Lightning invoice (leave empty to consolidate to self)..." />
                                             <div class="form-text">
-                                                <span text-translate="true">Ark address = offchain VTXO, Bitcoin address = onchain output, or BOLT11 invoice (single output only). Leave empty to consolidate selected VTXOs to self.</span>
+                                                <span text-translate="true">Arkade address = offchain VTXO, Bitcoin address = onchain output, or BOLT11 invoice (single output only). Leave empty to consolidate selected VTXOs to self.</span>
                                             </div>
                                             @if (!string.IsNullOrEmpty(output.Error))
                                             {
@@ -290,7 +290,7 @@
                                 <input type="text"
                                        name="Outputs[${outputIndex}].Destination"
                                        class="form-control destination-input"
-                                       placeholder="Ark address, BIP21 URI, or Lightning invoice..." />
+                                       placeholder="Arkade address, BIP21 URI, or Lightning invoice..." />
                             </div>
                             <div class="col-md-6">
                                 <label class="form-label">Amount (BTC)</label>
@@ -435,7 +435,7 @@
 
                     // Display
                     feeAmount.textContent = `${feeBtc} BTC (${feeSats.toLocaleString()} sats)`;
-                    feeDescription.textContent = result.feeDescription || 'Ark service fee';
+                    feeDescription.textContent = result.feeDescription || 'Arkade service fee';
                     netAmount.textContent = `${netBtc} BTC`;
 
                     if (result.isLightning && result.feePercentage) {

--- a/BTCPayServer.Plugins.ArkPayServer/Views/Ark/Intents.cshtml
+++ b/BTCPayServer.Plugins.ArkPayServer/Views/Ark/Intents.cshtml
@@ -12,7 +12,7 @@
 @inject ArkNetworkConfig ArkNetworkConfig
 
 @{
-    ViewData.SetActivePage(category: "Ark", activePage: "Intents", title: "Ark - Intents");
+    ViewData.SetActivePage(category: "Ark", activePage: "Intents", title: "Arkade - Intents");
     var storeId = ScopeProvider.GetCurrentStoreId();
     var stateFilterCount = GetFilterCount(Model.Search, "state");
 }
@@ -34,7 +34,7 @@
 <div id="descriptor" class="collapse">
     <div class="d-flex px-4 py-4 mb-4 bg-tile rounded">
         <div class="flex-fill">
-            <p text-translate="true" class="mb-2">Intents represent pending VTXO spending operations waiting to be batched by the Ark operator.</p>
+            <p text-translate="true" class="mb-2">Intents represent pending VTXO spending operations waiting to be batched by the Arkade operator.</p>
             <p text-translate="true" class="mb-3">Track your payment intents and their batch status here.</p>
         </div>
         <button type="button" class="btn-close ms-auto" data-bs-toggle="collapse" data-bs-target="#descriptor" aria-expanded="false" aria-label="Close">

--- a/BTCPayServer.Plugins.ArkPayServer/Views/Ark/ListWallets.cshtml
+++ b/BTCPayServer.Plugins.ArkPayServer/Views/Ark/ListWallets.cshtml
@@ -4,7 +4,7 @@
 @model IEnumerable<ArkWalletEntity>
 
 @{
-    ViewData.SetActivePage(category: "Server", activePage: "ArkWallets", title: "Ark - Wallets");
+    ViewData.SetActivePage(category: "Server", activePage: "ArkWallets", title: "Arkade - Wallets");
 }
 
 <div class="sticky-header">
@@ -140,6 +140,6 @@
 else
 {
     <p class="text-secondary mt-3" text-translate="true">
-        No Ark wallets found.
+        No Arkade wallets found.
     </p>
 }

--- a/BTCPayServer.Plugins.ArkPayServer/Views/Ark/Send.cshtml
+++ b/BTCPayServer.Plugins.ArkPayServer/Views/Ark/Send.cshtml
@@ -9,7 +9,7 @@
 @inject BTCPayServer.Security.ContentSecurityPolicies Csp
 
 @{
-    ViewData.SetActivePage(category: "Ark", activePage: "Send", title: "Ark - Send");
+    ViewData.SetActivePage(category: "Ark", activePage: "Send", title: "Arkade - Send");
     Csp.UnsafeEval();
     var storeId = ScopeProvider.GetCurrentStoreId();
 }
@@ -94,8 +94,8 @@
 <div id="descriptor" class="collapse">
     <div class="d-flex px-4 py-4 mb-4 bg-tile rounded">
         <div class="flex-fill">
-            <p text-translate="true" class="mb-2">Send funds using the Ark protocol.</p>
-            <p text-translate="true" class="mb-3">Supports Ark addresses (instant offchain), Bitcoin addresses (batch settlement), and Lightning invoices (via swap).</p>
+            <p text-translate="true" class="mb-2">Send funds using the Arkade protocol.</p>
+            <p text-translate="true" class="mb-3">Supports Arkade addresses (instant offchain), Bitcoin addresses (batch settlement), and Lightning invoices (via swap).</p>
         </div>
         <button type="button" class="btn-close ms-auto" data-bs-toggle="collapse" data-bs-target="#descriptor" aria-expanded="false" aria-label="Close">
             <vc:icon symbol="close" />

--- a/BTCPayServer.Plugins.ArkPayServer/Views/Ark/Send2.cshtml
+++ b/BTCPayServer.Plugins.ArkPayServer/Views/Ark/Send2.cshtml
@@ -5,7 +5,7 @@
 @inject DisplayFormatter DisplayFormatter
 
 @{
-    ViewData.SetActivePage(category: "Ark", activePage: "Send2", title: "Ark - Send");
+    ViewData.SetActivePage(category: "Ark", activePage: "Send2", title: "Arkade - Send");
 }
 
 <div class="sticky-header">
@@ -138,7 +138,7 @@ else
                     </button>
                 </div>
                 <div class="form-text">
-                    Ark address, Lightning invoice, or BIP21 URI
+                    Arkade address, Lightning invoice, or BIP21 URI
                 </div>
             </div>
 

--- a/BTCPayServer.Plugins.ArkPayServer/Views/Ark/SpendOverview.cshtml
+++ b/BTCPayServer.Plugins.ArkPayServer/Views/Ark/SpendOverview.cshtml
@@ -5,7 +5,7 @@
 
 @{
     Layout = "_Layout";
-    ViewData.SetActivePage(category: "Ark", activePage: "SpendOverview", title: "Ark - Transfer");
+    ViewData.SetActivePage(category: "Ark", activePage: "SpendOverview", title: "Arkade - Transfer");
     var storeId = ScopeProvider.GetCurrentStoreId()!;
 }
 

--- a/BTCPayServer.Plugins.ArkPayServer/Views/Ark/StoreOverview.cshtml
+++ b/BTCPayServer.Plugins.ArkPayServer/Views/Ark/StoreOverview.cshtml
@@ -400,7 +400,7 @@
                             <div class="mb-3">
                                 <label asp-for="Destination" class="form-label">Destination Address</label>
                                 <input asp-for="Destination" class="form-control font-monospace" placeholder="ark1..." />
-                                <div class="form-text">Enter an Ark address to receive swept funds.</div>
+                                <div class="form-text">Enter an Arkade address to receive swept funds.</div>
                             </div>
                         }
                     </div>
@@ -439,7 +439,7 @@
                     <div class="modal-body">
                         <p class="text-muted small mb-3">
                             Boarding allows customers to pay invoices using an on-chain Bitcoin transaction.
-                            The funds are moved into the Ark VTXO tree in the next batch round.
+                            The funds are moved into the Arkade VTXO tree in the next batch round.
                             Only available when the store has no on-chain BTC payment method configured.
                         </p>
 

--- a/BTCPayServer.Plugins.ArkPayServer/Views/Ark/Swaps.cshtml
+++ b/BTCPayServer.Plugins.ArkPayServer/Views/Ark/Swaps.cshtml
@@ -13,7 +13,7 @@
 @inject ArkNetworkConfig ArkNetworkConfig
 
 @{
-    ViewData.SetActivePage(category: "Ark", activePage: "Swaps", title: "Ark - Swaps");
+    ViewData.SetActivePage(category: "Ark", activePage: "Swaps", title: "Arkade - Swaps");
     var storeId = ScopeProvider.GetCurrentStoreId();
     var mainnet = true;
     Network network = Network.Main;
@@ -49,7 +49,7 @@
 <div id="descriptor" class="collapse">
     <div class="d-flex px-4 py-4 mb-4 bg-tile rounded">
         <div class="flex-fill">
-            <p text-translate="true" class="mb-2">Swaps are Lightning-to-Ark exchanges facilitated by Boltz.</p>
+            <p text-translate="true" class="mb-2">Swaps are Lightning-to-Arkade exchanges facilitated by Boltz.</p>
             <p text-translate="true" class="mb-3">Track your swap history and status here.</p>
         </div>
         <button type="button" class="btn-close ms-auto" data-bs-toggle="collapse" data-bs-target="#descriptor" aria-expanded="false" aria-label="Close">

--- a/BTCPayServer.Plugins.ArkPayServer/Views/Ark/Vtxos.cshtml
+++ b/BTCPayServer.Plugins.ArkPayServer/Views/Ark/Vtxos.cshtml
@@ -17,7 +17,7 @@
 @inject TransactionLinkProviders TransactionLinkProviders
 
 @{
-    ViewData.SetActivePage(category: "Ark", activePage: "VTXOs", title: "Ark - VTXOs");
+    ViewData.SetActivePage(category: "Ark", activePage: "VTXOs", title: "Arkade - VTXOs");
     var storeId = ScopeProvider.GetCurrentStoreId();
     var statusFilterCount = GetFilterCount(Model.Search, "status");
     var chainTime = await ChainTimeProvider.GetChainTime(Context.RequestAborted);

--- a/BTCPayServer.Plugins.ArkPayServer/Views/Lightning/LNPaymentMethodSetupTab.cshtml
+++ b/BTCPayServer.Plugins.ArkPayServer/Views/Lightning/LNPaymentMethodSetupTab.cshtml
@@ -32,7 +32,7 @@
                         <code><b>type=</b>arkade;<b>wallet-id=</b>xxx...</code>
                     </li>
                 </ul>
-                <p class="my-2">Ensure you have first created an Ark wallet in your store</p>
+                <p class="my-2">Ensure you have first created an Arkade wallet in your store</p>
             </div>
         </div>
     </div>

--- a/BTCPayServer.Plugins.ArkPayServer/Views/Shared/Arkade/ArkadeMethodCheckout.cshtml
+++ b/BTCPayServer.Plugins.ArkPayServer/Views/Shared/Arkade/ArkadeMethodCheckout.cshtml
@@ -24,7 +24,7 @@
         <div v-if="model.address" class="input-group mt-3" data-testid="ark-address">
             <div class="form-floating" id="ArkAddress_@Model.PaymentMethodId">
                 <vc:truncate-center text="model.address" is-vue="true" padding="15" elastic="true" classes="form-control-plaintext" />
-                <label>Ark Address</label>
+                <label>Arkade Address</label>
             </div>
         </div>
         <div v-if="onchainAddress" class="input-group mt-3" data-testid="onchain-address">


### PR DESCRIPTION
## Use "Arkade" (not bare "Ark") in user-facing text

Brand consistency sweep across the plugin's user-visible strings. Triggered by a user pointing out `Receive ARK` as the page title and asking for a broader sweep.

### Rule applied
- **User-facing text** (page titles, headers, labels, button text, help copy, alerts, error/success messages, page-rendered JS strings) — uses **"Arkade"**.
- **Code identifiers** (the `Ark` controller name in `Url.Action(..., "Ark", ...)` / `asp-controller="Ark"`, type names like `ArkAddress` / `ArkVtxo` / `ArkadeBip21Builder`, the `?ark=` BIP-21 parameter, the `BTC-CHAIN` payment-method literal) — kept as-is. These are protocol/shorthand identifiers, not brand strings.

### Scope
**15 files, 46 string edits** across:
- Views: `InitialSetup`, `IntentBuilder`, `Contracts`, `ConfigurePayoutProcessor`, `StoreOverview`, `Send`, `Send2`, `Swaps`, `Vtxos`, `ListWallets`, `Intents`, `SpendOverview`, `LNPaymentMethodSetupTab`, `ArkadeMethodCheckout`.
- `ArkController.cs`: TempData success messages, exception messages on import, error responses on `/parse-destination` and `/estimate-fees`, fee-description fields on send/payout responses.

### Out of scope (intentionally)
- **`Receive.cshtml`** — covered separately by **#62** (vertical-stack + same brand sweep on that file). Avoided here to prevent merge conflict.
- **Code comments** (e.g. `// Ark addresses start with ark1/tark1` in client-side JS, `<!-- Ark Status -->` HTML comment in `_ServiceConnections.cshtml`) — internal documentation, not visible.
- **`ark/` BIP-21 parameter name** in user-facing copy that explains the URI format — that's the wire-protocol parameter name, kept lowercase verbatim.

### Test plan
- [x] No tests assert any of these specific strings (grep confirmed).
- [x] Sample diff manually inspected: only string-content changes, no API/type changes.
- [ ] CI green.
