### PR TITLE
feat(electrum): fall back to EsploraBlockchain when Electrum plugin is the backend

### DIFF
--- a/BTCPayServer.Plugins.ArkPayServer/ArkPlugin.cs
+++ b/BTCPayServer.Plugins.ArkPayServer/ArkPlugin.cs
@@ -152,36 +152,57 @@ public class ArkadePlugin : BaseBTCPayServerPlugin
         {
             var explorerClientProvider = provider.GetRequiredService<ExplorerClientProvider>();
             var providerTypeName = explorerClientProvider.GetType().FullName ?? "";
-            var isElectrum = providerTypeName.Contains("Electrum", StringComparison.OrdinalIgnoreCase);
+
+            // Two complementary signals because either alone is fragile:
+            //  - Type-name "Electrum" catches the documented Electrum plugin
+            //    even if it later wraps the provider in something whose
+            //    RPCClient happens to be non-null.
+            //  - RPCClient == null is the *actual* failure condition for
+            //    NBXplorerBlockchain (it dereferences .RPCClient on every
+            //    chain-time / fee / broadcast call). Any future shim that
+            //    nulls it out — Electrum or otherwise — gets caught here
+            //    rather than NRE'ing in production.
+            var btcExplorer = explorerClientProvider.GetExplorerClient("BTC");
+            var rpcClientNull = btcExplorer?.RPCClient is null;
+            var typeNameLooksElectrum = providerTypeName.Contains("Electrum", StringComparison.OrdinalIgnoreCase);
+            var useEsporaFallback = typeNameLooksElectrum || rpcClientNull;
 
             var pluginLogger = provider.GetService<ILogger<ArkadePlugin>>();
 
-            if (isElectrum)
+            if (useEsporaFallback)
             {
+                var trigger = (typeNameLooksElectrum, rpcClientNull) switch
+                {
+                    (true, true) => "type-name match + RPCClient is null",
+                    (true, false) => "type-name match",
+                    (false, true) => "RPCClient is null on the registered ExplorerClient",
+                    _ => "unknown"
+                };
+
                 var network = provider.GetRequiredService<ArkNetworkConfig>();
                 var esploraUri = network.EsploraUri;
                 if (string.IsNullOrWhiteSpace(esploraUri))
                 {
                     throw new InvalidOperationException(
-                        $"Electrum plugin is the registered ExplorerClientProvider ({providerTypeName}) " +
+                        $"Detected an NBXplorer-incompatible ExplorerClientProvider ({providerTypeName}, trigger: {trigger}) " +
                         "but ArkNetworkConfig.EsploraUri is null for this network. " +
-                        "The Arkade plugin needs an Esplora endpoint for IBitcoinBlockchain because " +
-                        "the Electrum shim does not expose a working RPCClient — set 'esplora' in " +
-                        "ark.json or pick a network preset (Mainnet/Mutinynet/Regtest) that includes it.");
+                        "NBXplorerBlockchain reaches into ExplorerClient.RPCClient which the shim does not expose; " +
+                        "the Arkade plugin needs an Esplora endpoint as a fallback. " +
+                        "Set 'esplora' in ark.json or pick a network preset (Mainnet/Mutinynet/Signet/Regtest) that includes it.");
                 }
 
                 var esploraLogger = provider.GetService<ILogger<EsploraBlockchain>>();
                 pluginLogger?.LogInformation(
-                    "Electrum plugin detected ({Provider}); using EsploraBlockchain at {Uri} for chain time / UTXO lookup / broadcast / fee estimation",
-                    providerTypeName, esploraUri);
+                    "NBXplorer-incompatible ExplorerClientProvider detected ({Provider}, trigger: {Trigger}); using EsploraBlockchain at {Uri} for chain time / UTXO lookup / broadcast / fee estimation",
+                    providerTypeName, trigger, esploraUri);
                 return new EsploraBlockchain(new Uri(esploraUri), esploraLogger);
             }
 
             var nbxLogger = provider.GetService<ILogger<NBXplorerBlockchain>>();
             pluginLogger?.LogInformation(
-                "Using NBXplorerBlockchain for chain time / UTXO lookup / broadcast / fee estimation (ExplorerClientProvider: {Provider})",
+                "Using NBXplorerBlockchain for chain time / UTXO lookup / broadcast / fee estimation (ExplorerClientProvider: {Provider}, RPCClient: non-null)",
                 providerTypeName);
-            return new NBXplorerBlockchain(explorerClientProvider.GetExplorerClient("BTC"), nbxLogger);
+            return new NBXplorerBlockchain(btcExplorer, nbxLogger);
         });
 
         // Intent scheduler
@@ -325,7 +346,17 @@ public class ArkadePlugin : BaseBTCPayServerPlugin
             ArkUri: !string.IsNullOrEmpty(fileConfig?.ArkUri) ? fileConfig.ArkUri : preset.ArkUri,
             ArkadeWalletUri: !string.IsNullOrEmpty(fileConfig?.ArkadeWalletUri) ? fileConfig.ArkadeWalletUri : preset.ArkadeWalletUri,
             BoltzUri: !string.IsNullOrEmpty(fileConfig?.BoltzUri) ? fileConfig.BoltzUri : preset.BoltzUri,
-            ExplorerUri: !string.IsNullOrEmpty(fileConfig?.ExplorerUri) ? fileConfig.ExplorerUri : preset.ExplorerUri
+            ExplorerUri: !string.IsNullOrEmpty(fileConfig?.ExplorerUri) ? fileConfig.ExplorerUri : preset.ExplorerUri,
+            // EsploraUri / ElectrumWsUri / ElectrumTcpUri arrived in
+            // ArkNetworkConfig via NNark dotnet-sdk#96. They MUST be carried
+            // through here too — otherwise the merge silently nulls the
+            // preset's Esplora endpoint and operators with a custom ark.json
+            // hit the InvalidOperationException in the IBitcoinBlockchain
+            // factory the moment they co-install the Electrum plugin (same
+            // failure mode as v2.1.14's ExplorerUri-merge regression).
+            EsploraUri: !string.IsNullOrEmpty(fileConfig?.EsploraUri) ? fileConfig.EsploraUri : preset.EsploraUri,
+            ElectrumWsUri: !string.IsNullOrEmpty(fileConfig?.ElectrumWsUri) ? fileConfig.ElectrumWsUri : preset.ElectrumWsUri,
+            ElectrumTcpUri: !string.IsNullOrEmpty(fileConfig?.ElectrumTcpUri) ? fileConfig.ElectrumTcpUri : preset.ElectrumTcpUri
         );
     }
 
@@ -342,7 +373,14 @@ public class ArkadePlugin : BaseBTCPayServerPlugin
                 ArkUri: "https://signet.arkade.sh",
                 ArkadeWalletUri: "https://signet.arkade.money",
                 BoltzUri: null,
-                ExplorerUri: "https://explorer.signet.arkade.sh");
+                ExplorerUri: "https://explorer.signet.arkade.sh",
+                // Signet endpoints mirror the canonical ts-sdk defaults
+                // (https://github.com/arkade-os/ts-sdk/blob/main/src/providers/onchain.ts
+                // and electrum.ts). NNark only ships Mainnet/Mutinynet/Regtest
+                // presets so the plugin fills these per-network here.
+                EsploraUri: "https://mempool.signet.arkade.sh/api",
+                ElectrumWsUri: "wss://electrum.signet.arkade.sh",
+                ElectrumTcpUri: "tcp://electrum.signet.arkade.sh:50001");
 
         return null;
     }

--- a/BTCPayServer.Plugins.ArkPayServer/ArkPlugin.cs
+++ b/BTCPayServer.Plugins.ArkPayServer/ArkPlugin.cs
@@ -129,17 +129,60 @@ public class ArkadePlugin : BaseBTCPayServerPlugin
         services.AddSingleton<ISafetyService, NArk.Safety.AsyncKeyedLock.AsyncSafetyService>();
 
         // Unified blockchain backend (chain time + boarding-UTXO lookup +
-        // broadcast + tx status + fee estimation). Pass the inner provider's
-        // logger so the cache-fallback warning (emitted when Bitcoin Core
-        // RPC blips and we serve a stale chain time) is visible in plugin
-        // logs rather than swallowed.
-        services.AddSingleton<NBXplorerBlockchain>(provider =>
+        // broadcast + tx status + fee estimation).
+        //
+        // Default backend is NBXplorerBlockchain, which reaches into
+        // ExplorerClient.RPCClient.SendCommandAsync for chain time, fee
+        // estimation, etc.
+        //
+        // When the BTCPay Electrum plugin
+        // (Kukks/BTCPayServerPlugins/Plugins/BTCPayServer.Plugins.Electrum)
+        // is co-installed, it rip-and-replaces NBXplorer's DI registrations
+        // and substitutes its own ExplorerClient shim whose RPCClient is
+        // null — NBXplorerBlockchain would NRE on every chain-time / fee
+        // call. Detect that case by the registered ExplorerClientProvider's
+        // concrete type name and swap in EsploraBlockchain (REST against
+        // the network's default Esplora endpoint) instead.
+        //
+        // The inner provider's logger is passed so the cache-fallback
+        // warning (emitted when the chain-time call fails transiently
+        // and we serve the cached value) is visible in plugin logs
+        // rather than swallowed.
+        services.AddSingleton<IBitcoinBlockchain>(provider =>
         {
             var explorerClientProvider = provider.GetRequiredService<ExplorerClientProvider>();
-            var logger = provider.GetService<ILogger<NBXplorerBlockchain>>();
-            return new NBXplorerBlockchain(explorerClientProvider.GetExplorerClient("BTC"), logger);
+            var providerTypeName = explorerClientProvider.GetType().FullName ?? "";
+            var isElectrum = providerTypeName.Contains("Electrum", StringComparison.OrdinalIgnoreCase);
+
+            var pluginLogger = provider.GetService<ILogger<ArkadePlugin>>();
+
+            if (isElectrum)
+            {
+                var network = provider.GetRequiredService<ArkNetworkConfig>();
+                var esploraUri = network.EsploraUri;
+                if (string.IsNullOrWhiteSpace(esploraUri))
+                {
+                    throw new InvalidOperationException(
+                        $"Electrum plugin is the registered ExplorerClientProvider ({providerTypeName}) " +
+                        "but ArkNetworkConfig.EsploraUri is null for this network. " +
+                        "The Arkade plugin needs an Esplora endpoint for IBitcoinBlockchain because " +
+                        "the Electrum shim does not expose a working RPCClient — set 'esplora' in " +
+                        "ark.json or pick a network preset (Mainnet/Mutinynet/Regtest) that includes it.");
+                }
+
+                var esploraLogger = provider.GetService<ILogger<EsploraBlockchain>>();
+                pluginLogger?.LogInformation(
+                    "Electrum plugin detected ({Provider}); using EsploraBlockchain at {Uri} for chain time / UTXO lookup / broadcast / fee estimation",
+                    providerTypeName, esploraUri);
+                return new EsploraBlockchain(new Uri(esploraUri), esploraLogger);
+            }
+
+            var nbxLogger = provider.GetService<ILogger<NBXplorerBlockchain>>();
+            pluginLogger?.LogInformation(
+                "Using NBXplorerBlockchain for chain time / UTXO lookup / broadcast / fee estimation (ExplorerClientProvider: {Provider})",
+                providerTypeName);
+            return new NBXplorerBlockchain(explorerClientProvider.GetExplorerClient("BTC"), nbxLogger);
         });
-        services.AddSingleton<IBitcoinBlockchain>(sp => sp.GetRequiredService<NBXplorerBlockchain>());
 
         // Intent scheduler
         services.Configure<SimpleIntentSchedulerOptions>(options =>


### PR DESCRIPTION
## Fall back to `EsploraBlockchain` when the Electrum plugin is the backend

### Why
The BTCPay [Electrum plugin](https://github.com/Kukks/BTCPayServerPlugins/tree/master/Plugins/BTCPayServer.Plugins.Electrum) rip-and-replaces all of NBXplorer's DI registrations (`ExplorerClientProvider`, `NBXplorerConnectionFactory`, `NBXplorerListener`, etc.) with its own shims. The shims cover most of NBXplorer's HTTP API surface, but `ExplorerClient.RPCClient` is left **null** because the Electrum protocol doesn't have a Bitcoin Core RPC equivalent. Our `NBXplorerBlockchain` reaches into `_explorerClient.RPCClient.SendCommandAsync` for chain time, fee estimation, and broadcast paths — so the moment the Electrum plugin is co-installed, **every chain-time / fee call in the Arkade plugin NREs**.

### Change
`ArkPlugin.RegisterArkServices` (the `IBitcoinBlockchain` registration) now inspects the registered `ExplorerClientProvider`'s concrete type name. When it contains `"Electrum"` it returns an **`EsploraBlockchain`** (REST against the network's default Esplora endpoint) instead of `NBXplorerBlockchain`. The endpoint comes from `ArkNetworkConfig.EsploraUri`, populated per-network from the canonical Arkade ts-sdk defaults via [arkade-os/dotnet-sdk#96](https://github.com/arkade-os/dotnet-sdk/pull/96):

| Network | `EsploraUri` |
|---|---|
| Mainnet | `https://mempool.arkade.sh/api` |
| Mutinynet | `https://mempool.mutinynet.arkade.sh/api` |
| Regtest | `http://localhost:3000` |

When Electrum is the backend **and** `EsploraUri` is null, the factory throws on first resolution with a clear remediation message (set `esplora` in `ark.json`, or pick a network preset that includes it) instead of NRE'ing later in production. Both backends log which one was selected at startup so operators can grep the choice from logs.

### Companion fix in the Electrum plugin
This PR fixes the **chain-time / fee / broadcast** paths. The **inbound-tx event** path needs Kukks/BTCPayServerPlugins#132 — the Electrum plugin currently doesn't republish `NewOnChainTransactionEvent`, so `BoardingTransactionListener.cs:34` never fires under Electrum and boarding-address payments are silently undetected. With both PRs in, the Arkade plugin works end-to-end alongside the Electrum plugin.

### Submodule bump
NNark `a89d47a → fa6092d` (master tip; #96 brings the new `ArkNetworkConfig` fields).

### Test plan
- [x] Plugin builds clean (0 errors).
- [ ] CI green.
- [ ] Manual smoke: install both Arkade plugin + Electrum plugin on a test BTCPay; confirm the log line `Electrum plugin detected ...; using EsploraBlockchain at ...` appears at startup and chain-time / fee calls succeed.
