### PR TITLE
fix: surface unconfirmed boarding state + bump SDK (spend filter + sync self-heal)

### DIFF
--- a/BTCPayServer.Plugins.ArkPayServer/Models/ArkPaymentDataViewModel.cs
+++ b/BTCPayServer.Plugins.ArkPayServer/Models/ArkPaymentDataViewModel.cs
@@ -9,4 +9,11 @@ public class ArkPaymentDataViewModel
     public DateTimeOffset ReceivedTime { get; set; }
     public string Currency { get; set; }
     public bool IsBoarding { get; set; }
+
+    /// <summary>
+    /// True for a boarding payment whose on-chain funding tx is still
+    /// unconfirmed (payment status Processing). Such a payment is not yet
+    /// spendable or settleable.
+    /// </summary>
+    public bool IsUnconfirmed { get; set; }
 }

--- a/BTCPayServer.Plugins.ArkPayServer/Views/Ark/ArkPaymentData.cshtml
+++ b/BTCPayServer.Plugins.ArkPayServer/Views/Ark/ArkPaymentData.cshtml
@@ -1,5 +1,6 @@
 @using System.Globalization
 @using BTCPayServer.Abstractions.Extensions
+@using BTCPayServer.Data
 @using BTCPayServer.Payments
 @using BTCPayServer.Plugins.ArkPayServer.Helpers
 @using BTCPayServer.Plugins.ArkPayServer.Models
@@ -54,6 +55,8 @@
 			Contract = contractString,
 			Currency = payment.Currency,
 			IsBoarding = isBoarding,
+			// Boarding payment stays Processing until its on-chain funding tx confirms.
+			IsUnconfirmed = isBoarding && payment.Status == PaymentStatus.Processing,
 		};
 		return vm;
 	}).Where(c => c != null).ToList();
@@ -100,6 +103,10 @@
 		                @if (payment.IsBoarding)
 		                {
 			                <span class="badge text-bg-info" title="On-chain boarding payment to the P2TR boarding address">Boarding</span>
+			                @if (payment.IsUnconfirmed)
+			                {
+				                <span class="badge text-bg-warning" title="On-chain funding tx not yet confirmed — not spendable or settled yet">Unconfirmed</span>
+			                }
 		                }
 		                else
 		                {

--- a/BTCPayServer.Plugins.ArkPayServer/Views/Ark/Vtxos.cshtml
+++ b/BTCPayServer.Plugins.ArkPayServer/Views/Ark/Vtxos.cshtml
@@ -153,6 +153,8 @@
                         var isSpendable = Model.SpendableOutpoints.Contains(vtxo.OutPoint);
                         var outpointValue = $"{vtxo.TransactionId}:{vtxo.TransactionOutputIndex}";
                         var isSpent = vtxo.IsSpent();
+                        // On-chain (boarding) UTXO still in the mempool: not spendable or settled yet.
+                        var isUnconfirmed = vtxo.IsUnconfirmedOnchain();
 
                         // Get contract info for this VTXO
                         Model.VtxoContracts.TryGetValue(vtxo.Script, out var contract);
@@ -197,15 +199,19 @@
                                 }
                             </td>
                             <td class="align-middle d-flex flex-wrap gap-1">
+                                @if (isUnconfirmed)
+                                {
+                                    <span class="badge text-bg-warning">Unconfirmed</span>
+                                }
                                 @if (vtxo.IsRecoverable(chainTime))
                                 {
                                     <span class="badge text-bg-warning">Recoverable</span>
                                 }
-                                @if (isSpendable)
+                                @if (isSpendable && !isUnconfirmed)
                                 {
                                     <span class="badge text-bg-info">Spendable</span>
                                 }
-                                @if (!vtxo.Preconfirmed)
+                                @if (!vtxo.Preconfirmed && !isUnconfirmed)
                                 {
                                     <span class="badge text-bg-light">Settled</span>
                                 }

--- a/BTCPayServer.Plugins.ArkPayServer/Views/Shared/_VtxoTable.cshtml
+++ b/BTCPayServer.Plugins.ArkPayServer/Views/Shared/_VtxoTable.cshtml
@@ -121,6 +121,10 @@
                             {
                                 <span class="badge text-bg-secondary">Spent</span>
                             }
+                            else if (vtxo.IsUnconfirmedOnchain())
+                            {
+                                <span class="badge text-bg-warning">Unconfirmed</span>
+                            }
                             else if (vtxo.IsRecoverable(chainTime))
                             {
                                 <span class="badge text-bg-warning">Recoverable</span>
@@ -129,7 +133,7 @@
                             {
                                 <span class="badge text-bg-success">Unspent</span>
                             }
-                            @if (showSpendableStatus && isSpendable)
+                            @if (showSpendableStatus && isSpendable && !vtxo.IsUnconfirmedOnchain())
                             {
                                 <span class="badge text-bg-info">Spendable</span>
                             }


### PR DESCRIPTION
## Summary
Two related fixes for boarding payments, plus the SDK bump that backs them.

**Display (plugin):** an in-mempool boarding UTXO was shown as **Spendable + Settled + Unspent**, which is wrong — its funding tx isn't confirmed, so it's neither spendable nor settleable (arkd rejects unconfirmed boarding inputs at settle time). Now it shows **Unconfirmed**.
- `Vtxos.cshtml`: adds an **Unconfirmed** badge; suppresses **Spendable**/**Settled** when `ArkVtxo.IsUnconfirmedOnchain()`.
- `_VtxoTable.cshtml` (StoreOverview): shows **Unconfirmed** instead of green **Unspent**.
- `ArkPaymentData.cshtml` + view model: flags a boarding payment row **Unconfirmed** while its funding tx is still `Processing`.

**SDK bump** `b55c886 → ce127ef`:
- **#101** — `GetAvailableCoins` excludes unconfirmed on-chain (boarding) VTXOs (`ArkVtxo.IsUnconfirmedOnchain()`), so an in-mempool boarding UTXO is no longer offered as a spendable coin.
- **#102** — `VtxoSynchronizationService` derives the active-script set **fresh each poll** (provider-agnostic) and reconciles the stream subscription, fixing a class of bug where a payment to a freshly-derived receive contract went undetected (cached watch set desynced) until a manual sync. Includes a per-provider-isolation guard and a `DISTINCT script` projection for the per-tick derive.

## Why bundled
The plugin badge change consumes the new `IsUnconfirmedOnchain()` API, so it requires the submodule bump. #102 rides along in the same bump (it's on master between the old and new pointers).

## Test plan
- [x] `dotnet build BTCPayServer.Plugins.ArkPayServer` — 0 errors (views compile against the bumped SDK)
- [x] SDK side: `dotnet test NArk.Tests` 400/400 (in #101/#102)
- [ ] CI green on this PR
- [ ] Manual: pay a boarding address on-chain → invoice row + VTXO table show **Unconfirmed** (not Spendable/Settled) until the funding tx confirms; confirm it flips to Settled/Spendable after confirmation.