### PR TITLE
chore: release v2.1.17

### DIFF
--- a/BTCPayServer.Plugins.ArkPayServer/BTCPayServer.Plugins.ArkPayServer.csproj
+++ b/BTCPayServer.Plugins.ArkPayServer/BTCPayServer.Plugins.ArkPayServer.csproj
@@ -7,7 +7,7 @@
 
         <Product>Arkade - Beta</Product>
         <Description>Programmable money for sovereign business. Easily accept payments through Arkade &amp; Lightning non-custodially without complexity.</Description>
-        <Version>2.1.16</Version>
+        <Version>2.1.17</Version>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
         <GenerateRuntimeConfigDevFile>true</GenerateRuntimeConfigDevFile>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.1.17] - 2026-05-22
+
+### SDK (NNark)
+- **Indexer script subscription updated in place instead of restarting.** `VtxoSynchronizationService` now keeps one arkd `GetSubscription` stream open and adds/removes scripts via Subscribe/Unsubscribe as contracts come and go, rather than tearing the stream down and resubscribing on every change. It reconnects on the same subscription id, recreates it only if arkd reports it gone (TTL after a disconnect), and tears it down when the active set is empty; the 5-second fresh-derive safety-net poll remains the backstop, so detection never depends on the stream surviving. Removes per-change stream churn and the teardown/recreate window where a pushed event could be missed (#103).
+
 ## [2.1.16] - 2026-05-22
 
 ### Bug Fixes


### PR DESCRIPTION
## Summary
Bumps the NNark submodule **ce127ef → a9e990f** and cuts **v2.1.17**.

Picks up the SDK's in-place indexer script subscription (#103): `VtxoSynchronizationService` now keeps one arkd `GetSubscription` stream open and adds/removes scripts via Subscribe/Unsubscribe as contracts come and go, instead of tearing the stream down and resubscribing on every change. Same-id reconnect, recreate only if arkd GC's the subscription, teardown on empty set; the 5-second fresh-derive safety-net poll remains the backstop.

This is a transparent sync-efficiency improvement for the plugin — no plugin API or behavior change.

## Test plan
- [x] `dotnet build BTCPayServer.Plugins.ArkPayServer` — 0 errors against a9e990f
- [x] SDK side: 404/404 unit tests + E2E green (in #103)
- [ ] Plugin CI green on this PR (build + E2E against the bumped SDK)