### PR TITLE
fix(checkout): don't crash on unactivated bitcoin prompt (v2.1.18)

### DIFF
--- a/BTCPayServer.Plugins.ArkPayServer/BTCPayServer.Plugins.ArkPayServer.csproj
+++ b/BTCPayServer.Plugins.ArkPayServer/BTCPayServer.Plugins.ArkPayServer.csproj
@@ -7,7 +7,7 @@
 
         <Product>Arkade - Beta</Product>
         <Description>Programmable money for sovereign business. Easily accept payments through Arkade &amp; Lightning non-custodially without complexity.</Description>
-        <Version>2.1.17</Version>
+        <Version>2.1.18</Version>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
         <GenerateRuntimeConfigDevFile>true</GenerateRuntimeConfigDevFile>

--- a/BTCPayServer.Plugins.ArkPayServer/PaymentHandler/ArkadeCheckoutModelExtension.cs
+++ b/BTCPayServer.Plugins.ArkPayServer/PaymentHandler/ArkadeCheckoutModelExtension.cs
@@ -3,6 +3,7 @@ using BTCPayServer.Models.InvoicingModels;
 using BTCPayServer.Payments;
 using BTCPayServer.Services.Invoices;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
 
 namespace BTCPayServer.Plugins.ArkPayServer.PaymentHandler;
@@ -20,6 +21,7 @@ public class ArkadeCheckoutModelExtension: ICheckoutModelExtension, IGlobalCheck
     // Lazily resolving through the provider sidesteps the cycle since the
     // singleton is cached by the time we actually enumerate at request time.
     private readonly IServiceProvider _serviceProvider;
+    private readonly ILogger<ArkadeCheckoutModelExtension> _logger;
 
     private static readonly PaymentMethodId BitcoinOnchainPmi =
         PaymentTypes.CHAIN.GetPaymentMethodId("BTC");
@@ -28,11 +30,13 @@ public class ArkadeCheckoutModelExtension: ICheckoutModelExtension, IGlobalCheck
         IEnumerable<IPaymentLinkExtension> paymentLinkExtensions,
         IServiceProvider serviceProvider,
         PaymentMethodHandlerDictionary handlers,
-        ArkadePaymentMethodHandler handler)
+        ArkadePaymentMethodHandler handler,
+        ILogger<ArkadeCheckoutModelExtension> logger)
     {
         _handler = handler;
         _handlers = handlers;
         _serviceProvider = serviceProvider;
+        _logger = logger;
         var linkList = paymentLinkExtensions as IList<IPaymentLinkExtension> ?? paymentLinkExtensions.ToList();
         _arkadePaymentLinkExtension =
             linkList.SingleOrDefault(p => p.PaymentMethodId == ArkadePlugin.ArkadePaymentMethodId) ??
@@ -62,7 +66,23 @@ public class ArkadeCheckoutModelExtension: ICheckoutModelExtension, IGlobalCheck
         // PaymentMethodId == "BTC-CHAIN") would have appended to the bitcoin
         // tab's URL. They never see the Arkade tab on their own — we have to
         // synthesise their pipeline. See HarvestUpstreamGlobalParams below.
-        var (extraForUrl, extraForQr) = HarvestUpstreamGlobalParams(context);
+        //
+        // Best-effort: this replays third-party plugin hooks against a synthetic
+        // bitcoin context, so it's exposed to their (and BTCPay's) failure modes.
+        // A throw here would propagate out of ModifyCheckoutModel and make BTCPay
+        // disable the entire Arkade plugin, so any failure must degrade to "no
+        // harvested params" rather than break checkout rendering.
+        var extraForUrl = "";
+        var extraForQr = "";
+        try
+        {
+            (extraForUrl, extraForQr) = HarvestUpstreamGlobalParams(context);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Failed to harvest upstream BIP-21 params for the Arkade checkout; rendering without them");
+        }
 
         // Full BIP21 with all params for "Pay in wallet" link
         context.Model.InvoiceBitcoinUrl = AppendQuery(paymentLink, extraForUrl);
@@ -107,7 +127,13 @@ public class ArkadeCheckoutModelExtension: ICheckoutModelExtension, IGlobalCheck
     private (string ExtraForUrl, string ExtraForQr) HarvestUpstreamGlobalParams(CheckoutModelContext realCtx)
     {
         var bitcoinPrompt = realCtx.InvoiceEntity.GetPaymentPrompt(BitcoinOnchainPmi);
-        if (bitcoinPrompt is null || _bitcoinPaymentLinkExtension is null) return ("", "");
+        // Require an ACTIVATED bitcoin prompt: with lazy payment methods the prompt
+        // exists but stays unactivated (Details == null) until the customer opens the
+        // bitcoin tab. BitcoinPaymentLinkExtension.GetPaymentLink → ParsePaymentPromptDetails
+        // does details.ToObject<>() and NREs on null Details. There's also nothing to
+        // harvest from a tab that was never activated (its plugins didn't run either).
+        if (bitcoinPrompt is not { Activated: true, Details: not null } || _bitcoinPaymentLinkExtension is null)
+            return ("", "");
         var bitcoinHandler = _handlers.TryGet(BitcoinOnchainPmi);
         if (bitcoinHandler is null) return ("", "");
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.1.18] - 2026-05-22
+
+### Bug Fixes
+- **Checkout no longer crashes (and disables the plugin) when the bitcoin payment method is unactivated.** With lazy payment methods, the BTC-CHAIN prompt exists on an invoice but stays unactivated (`Details`/`Destination` null) until the customer opens the bitcoin tab. The Arkade checkout's BIP-21 "harvest" step (which replays bitcoin-onchain-only plugins like PayJoin/Branta to preserve their params on the unified Arkade QR) only checked that the bitcoin prompt was non-null, then called `BitcoinPaymentLinkExtension.GetPaymentLink` → `ParsePaymentPromptDetails`, which `NullReferenceException`ed on the null `Details`. Because that threw out of `ICheckoutModelExtension.ModifyCheckoutModel`, BTCPay disabled the **entire** Arkade plugin whenever such a checkout was opened. Now the harvest requires an activated bitcoin prompt (nothing to harvest from an unactivated tab anyway), and the whole harvest is wrapped so any failure degrades to "no harvested params" instead of breaking checkout rendering.
+
 ## [2.1.17] - 2026-05-22
 
 ### SDK (NNark)


### PR DESCRIPTION
## The crash
Opening an Arkade checkout disabled the **entire plugin**:
```
System.NullReferenceException
  at BitcoinLikePaymentHandler.ParsePaymentPromptDetails(JToken details)   // details.ToObject<>() on null
  at BitcoinPaymentLinkExtension.GetPaymentLink(prompt, urlHelper)
  at ArkadeCheckoutModelExtension.HarvestUpstreamGlobalParams(...)  line 114
  at ArkadeCheckoutModelExtension.ModifyCheckoutModel(...)          line 65
  at UIInvoiceController.GetCheckoutModel(...)
→ "Unhandled exception caused by plugin 'BTCPayServer.Plugins.ArkPayServer', disabling it and restarting..."
```

## Root cause
With **lazy payment methods**, the BTC-CHAIN prompt exists on the invoice but stays **unactivated** (`Details`/`Destination` null) until the customer opens the bitcoin tab. `HarvestUpstreamGlobalParams` guarded only `bitcoinPrompt is null`, then called `GetPaymentLink` → `ParsePaymentPromptDetails(prompt.Details)`, and BTCPay's handler does `details.ToObject<BitcoinPaymentPromptDetails>()` → **NRE on null `Details`**. Since the throw escaped `ModifyCheckoutModel`, BTCPay disabled the whole Arkade plugin for every store.

The essential Arkade-link path (`ArkadePaymentLinkExtension`) already dodged this via its `!string.IsNullOrEmpty(onchain?.Destination)` guard — only the harvest path was missing the activation check.

## Fix (two layers)
- **Root cause:** the harvest now requires an **activated** bitcoin prompt (`Activated && Details != null`) — an unactivated tab has nothing to harvest, and its onchain-only plugins never ran either. Mirrors BTCPay's own `Prompt.Activated` gating.
- **Defense in depth:** the best-effort harvest is wrapped so any failure (this NRE or a future one) degrades to "no harvested params" + a logged warning, instead of taking the plugin down.

Bumps to **v2.1.18**.

## Test plan
- [x] `dotnet build BTCPayServer.Plugins.ArkPayServer` — 0 errors
- [ ] Plugin CI green (build + E2E)
- [ ] Manual: open an Arkade checkout on a store using lazy/on-chain BTC where the bitcoin tab hasn't been activated → page renders (no plugin crash); harvested params still appear once the bitcoin tab is activated.

> No unit test added: the plugin has no unit-test harness and `ModifyCheckoutModel` needs heavy BTCPay host scaffolding (a real `ArkadePaymentMethodHandler` + a fully-built `InvoiceEntity` with mixed activated/unactivated prompts). The catch-all makes the catastrophic outcome structurally impossible regardless; a plugin unit-test project / E2E lazy-activation case would be a good follow-up.