### PR TITLE
feat(ui): friendly "Arkade operator unavailable" errors + status banner

### DIFF
--- a/BTCPayServer.Plugins.ArkPayServer/ArkPlugin.cs
+++ b/BTCPayServer.Plugins.ArkPayServer/ArkPlugin.cs
@@ -260,6 +260,10 @@ public class ArkadePlugin : BaseBTCPayServerPlugin
 
         services.AddSingleton<ArkadeSpendingService>();
 
+        // Tracks Arkade-operator reachability so plugin pages can show a friendly
+        // "operator unavailable" banner instead of leaking raw gRPC/HTTP errors.
+        services.AddSingleton<ArkOperatorHealthService>();
+
         services.AddSingleton<ISweepPolicy, DestinationSweepPolicy>();
 
         services.AddSingleton<ArkadeCheckoutModelExtension>();

--- a/BTCPayServer.Plugins.ArkPayServer/Controllers/ArkController.cs
+++ b/BTCPayServer.Plugins.ArkPayServer/Controllers/ArkController.cs
@@ -63,6 +63,7 @@ public class ArkController(
     StoreRepository storeRepository,
     PaymentMethodHandlerDictionary paymentMethodHandlerDictionary,
     IClientTransport clientTransport,
+    ArkOperatorHealthService arkOperatorHealth,
     ArkadeSpendingService arkadeSpendingService,
     ArkAutomatedPayoutSenderFactory payoutSenderFactory,
     PayoutProcessorService payoutProcessorService,
@@ -150,7 +151,7 @@ public class ArkController(
                 }
                 catch (Exception ex)
                 {
-                    TempData[WellKnownTempData.ErrorMessage] = "Could not update wallet: " + ex.Message;
+                    TempData[WellKnownTempData.ErrorMessage] = DescribeArkError(ex, "Could not update wallet");
                     return View(model);
                 }
             }
@@ -260,7 +261,7 @@ public class ArkController(
         }
         catch (Exception ex)
         {
-            TempData[WellKnownTempData.ErrorMessage] = $"Unable to fetch balances: {ex.Message}";
+            TempData[WellKnownTempData.ErrorMessage] = DescribeArkError(ex, "Unable to fetch balances");
         }
 
         var signerAvailable = await walletProvider.GetAddressProviderAsync(config.WalletId!, cancellationToken) != null;
@@ -367,7 +368,7 @@ public class ArkController(
             CanManagePrivateKeys = canManagePrivateKeys,
             ArkOperatorUrl = arkNetworkConfig.ArkUri,
             ArkOperatorConnected = arkOperatorConnected,
-            ArkOperatorError = arkOperatorError,
+            ArkOperatorError = ArkOperatorAvailability.DescribeMessage(arkOperatorError),
             BoltzUrl = arkNetworkConfig.BoltzUri,
             BoltzConnected = boltzConnected,
             BoltzError = boltzError,
@@ -454,7 +455,7 @@ public class ArkController(
         }
         catch (Exception ex)
         {
-            TempData[WellKnownTempData.ErrorMessage] = $"Failed to check receive address: {ex.Message}";
+            TempData[WellKnownTempData.ErrorMessage] = DescribeArkError(ex, "Failed to check receive address");
         }
 
         return View(model);
@@ -505,7 +506,7 @@ public class ArkController(
         }
         catch (Exception ex)
         {
-            TempData[WellKnownTempData.ErrorMessage] = $"Failed to generate address: {ex.Message}";
+            TempData[WellKnownTempData.ErrorMessage] = DescribeArkError(ex, "Failed to generate address");
         }
 
         return RedirectToAction(nameof(Receive), new { storeId });
@@ -685,7 +686,7 @@ public class ArkController(
         }
         catch (ArkadePaymentFailedException e)
         {
-            TempData[WellKnownTempData.ErrorMessage] = $"Payment failed: reason: {e.Message}";
+            TempData[WellKnownTempData.ErrorMessage] = DescribeArkError(e, "Payment failed: reason");
             return RedirectToAction(nameof(SpendOverview),
                 new {storeId = store.Id, destinations = model.PrefilledDestination});
         }
@@ -2541,7 +2542,7 @@ public class ArkController(
         }
         catch (Exception ex)
         {
-            TempData[WellKnownTempData.ErrorMessage] = $"Failed to create refresh intent: {ex.Message}";
+            TempData[WellKnownTempData.ErrorMessage] = DescribeArkError(ex, "Failed to create refresh intent");
         }
 
         return RedirectToAction(nameof(StoreOverview), new { storeId });
@@ -2987,7 +2988,7 @@ public class ArkController(
             DefaultAddress = defaultAddress,
             ArkOperatorUrl = arkNetworkConfig.ArkUri,
             ArkOperatorConnected = arkOperatorConnected,
-            ArkOperatorError = arkOperatorError,
+            ArkOperatorError = ArkOperatorAvailability.DescribeMessage(arkOperatorError),
             BoltzUrl = arkNetworkConfig.BoltzUri,
             BoltzConnected = boltzConnected,
             BoltzError = boltzError
@@ -3106,6 +3107,18 @@ public class ArkController(
     {
         TempData[WellKnownTempData.ErrorMessage] = message;
         return RedirectToAction(action, routeValues);
+    }
+
+    /// <summary>
+    /// Maps an exception to a user-facing message. When the Arkade operator is unreachable
+    /// it returns the friendly <see cref="ArkOperatorAvailability.UnavailableMessage"/> and
+    /// flips the status banner immediately (so the next page already reflects the outage);
+    /// otherwise it returns the original error prefixed with <paramref name="context"/>.
+    /// </summary>
+    private string DescribeArkError(Exception ex, string context)
+    {
+        arkOperatorHealth.ReportFailure(ex); // no-op unless ex looks like operator-unreachable
+        return ArkOperatorAvailability.Describe(ex, context);
     }
 
     /// <summary>

--- a/BTCPayServer.Plugins.ArkPayServer/Services/ArkOperatorAvailability.cs
+++ b/BTCPayServer.Plugins.ArkPayServer/Services/ArkOperatorAvailability.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Net.Http;
+using System.Net.Sockets;
+
+namespace BTCPayServer.Plugins.ArkPayServer.Services;
+
+/// <summary>
+/// Classifies exceptions/error strings that mean "the Arkade operator (arkd) is
+/// currently unreachable" — gRPC transport faults, HTTP 5xx from the operator's
+/// edge (e.g. a Cloudflare 5xx page), and raw socket/DNS/timeout failures — and maps
+/// them to a single user-facing message. Used so plugin pages show a friendly notice
+/// instead of a raw gRPC dump like
+/// <c>Status(StatusCode="Unknown", Detail="Bad gRPC response. HTTP status code: 530")</c>.
+/// </summary>
+public static class ArkOperatorAvailability
+{
+    /// <summary>The single user-facing message shown whenever the operator is unreachable.</summary>
+    public const string UnavailableMessage =
+        "The Arkade operator is currently unavailable. Please try again in a few moments.";
+
+    // Substrings that appear in operator-unreachable failures regardless of the concrete
+    // exception type. Matched case-insensitively against the whole exception chain. Kept
+    // deliberately specific so genuine application errors (bad input, validation, "not
+    // found") are NOT swallowed as "operator down".
+    private static readonly string[] UnavailableMarkers =
+    [
+        "bad grpc response",            // gRPC-over-HTTP got a non-gRPC body (e.g. a Cloudflare 5xx page)
+        "statuscode=\"unavailable\"",   // RpcException: server unreachable
+        "statuscode=\"deadlineexceeded\"",
+        "http status code: 5",          // 5xx from the operator's edge (502/503/530/...)
+        "connection refused",
+        "actively refused",             // Windows: TCP connect failure
+        "no connection could be made",
+        "name or service not known",    // Linux DNS failure
+        "no such host is known",        // Windows DNS failure
+        "connection reset",
+        "the operation has timed out",
+        "request timed out",
+    ];
+
+    /// <summary>
+    /// True when <paramref name="ex"/> (or any inner exception) indicates the Arkade
+    /// operator is unreachable rather than a genuine application/validation error.
+    /// </summary>
+    public static bool IsUnavailable(Exception? ex)
+    {
+        for (var current = ex; current is not null; current = current.InnerException)
+        {
+            // Type-based signals. We match RpcException by name rather than referencing
+            // Grpc.Core directly to avoid coupling the plugin's error helper to the gRPC
+            // package. OperationCanceledException is deliberately NOT treated as
+            // "operator down" — it is usually the caller/browser aborting the request.
+            var typeName = current.GetType().FullName ?? "";
+            if (typeName.Contains("RpcException", StringComparison.Ordinal) ||
+                current is HttpRequestException ||
+                current is SocketException ||
+                current is TimeoutException)
+            {
+                return true;
+            }
+
+            if (IsUnavailable(current.Message))
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// True when an already-stringified error message looks like an operator-unreachable
+    /// failure. Used where only the message survived (e.g. a cached status string).
+    /// </summary>
+    public static bool IsUnavailable(string? message)
+    {
+        if (string.IsNullOrEmpty(message))
+            return false;
+
+        foreach (var marker in UnavailableMarkers)
+            if (message.Contains(marker, StringComparison.OrdinalIgnoreCase))
+                return true;
+
+        return false;
+    }
+
+    /// <summary>
+    /// Returns the friendly <see cref="UnavailableMessage"/> when <paramref name="ex"/> is
+    /// an operator-unreachable failure; otherwise the original error text, prefixed with
+    /// <paramref name="fallbackPrefix"/> when one is supplied (so genuine errors keep their detail).
+    /// </summary>
+    public static string Describe(Exception ex, string? fallbackPrefix = null)
+    {
+        if (IsUnavailable(ex))
+            return UnavailableMessage;
+
+        return string.IsNullOrEmpty(fallbackPrefix) ? ex.Message : $"{fallbackPrefix}: {ex.Message}";
+    }
+
+    /// <summary>
+    /// Returns the friendly <see cref="UnavailableMessage"/> when <paramref name="message"/>
+    /// looks like an operator-unreachable failure; otherwise the original message unchanged.
+    /// </summary>
+    public static string? DescribeMessage(string? message) =>
+        IsUnavailable(message) ? UnavailableMessage : message;
+}

--- a/BTCPayServer.Plugins.ArkPayServer/Services/ArkOperatorHealthService.cs
+++ b/BTCPayServer.Plugins.ArkPayServer/Services/ArkOperatorHealthService.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NArk.Core.Transport;
+
+namespace BTCPayServer.Plugins.ArkPayServer.Services;
+
+/// <summary>Cached availability snapshot of the Arkade operator.</summary>
+/// <param name="Available">True when the operator answered its last probe.</param>
+/// <param name="Error">User-facing reason when unavailable; <c>null</c> when available.</param>
+public sealed record ArkOperatorStatus(bool Available, string? Error);
+
+/// <summary>
+/// Singleton that tracks whether the Arkade operator (arkd) is reachable, so plugin pages
+/// can show a persistent "operator unavailable" banner without each page paying the cost of
+/// a fresh probe. A successful <see cref="IClientTransport.GetServerInfoAsync"/> is the
+/// liveness signal.
+/// <para>
+/// The result is cached for <see cref="CacheTtl"/>. We deliberately cache the RESULT, not a
+/// <see cref="Task"/> — a cached faulted task would pin the "down" state forever after a
+/// single transient hiccup. Because the underlying transport caches a successful
+/// server-info for ~5 minutes, a freshly-downed operator can still probe "up" during that
+/// window; real plugin operations therefore feed their observed outcome in via
+/// <see cref="ReportFailure"/>/<see cref="ReportSuccess"/> so the banner flips immediately on
+/// a failed action instead of waiting for the transport cache to expire.
+/// </para>
+/// </summary>
+public sealed class ArkOperatorHealthService(IClientTransport clientTransport)
+{
+    private static readonly TimeSpan CacheTtl = TimeSpan.FromSeconds(15);
+    private readonly SemaphoreSlim _probeGate = new(1, 1);
+
+    private volatile ArkOperatorStatus? _cached;
+    private long _checkedAtTicks; // DateTimeOffset.UtcNow.UtcTicks — long read/write is atomic.
+
+    /// <summary>
+    /// Returns the operator status, re-probing only when the cached value is older than
+    /// <see cref="CacheTtl"/>. Never throws — a probe failure becomes an unavailable status.
+    /// </summary>
+    public async Task<ArkOperatorStatus> GetStatusAsync(CancellationToken cancellationToken = default)
+    {
+        if (TryGetFresh(out var fresh))
+            return fresh;
+
+        await _probeGate.WaitAsync(cancellationToken);
+        try
+        {
+            // Another caller may have refreshed the cache while we waited on the gate.
+            if (TryGetFresh(out fresh))
+                return fresh;
+
+            try
+            {
+                await clientTransport.GetServerInfoAsync(cancellationToken);
+                return Store(new ArkOperatorStatus(true, null));
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                // The caller (e.g. the browser) aborted the request — that is not an
+                // operator signal, so don't poison the cache with a false "down". Surface
+                // the last-known status, defaulting to available when we have none.
+                return _cached ?? new ArkOperatorStatus(true, null);
+            }
+            catch
+            {
+                // Any other failure means the operator did not answer the probe (gRPC
+                // transport fault, HTTP 5xx, the transport's own 10s fetch timeout, …).
+                return Store(new ArkOperatorStatus(false, ArkOperatorAvailability.UnavailableMessage));
+            }
+        }
+        finally
+        {
+            _probeGate.Release();
+        }
+    }
+
+    /// <summary>
+    /// Records a failure observed by a real operation. Flips the cached state to unavailable
+    /// (and resets the TTL) only when <paramref name="ex"/> looks like an operator-unreachable
+    /// failure — genuine application errors are ignored here.
+    /// </summary>
+    public void ReportFailure(Exception ex)
+    {
+        if (ArkOperatorAvailability.IsUnavailable(ex))
+            Store(new ArkOperatorStatus(false, ArkOperatorAvailability.UnavailableMessage));
+    }
+
+    /// <summary>Records a successful operator interaction, clearing any cached "unavailable" state.</summary>
+    public void ReportSuccess() => Store(new ArkOperatorStatus(true, null));
+
+    private bool TryGetFresh(out ArkOperatorStatus status)
+    {
+        var cached = _cached;
+        if (cached is not null &&
+            DateTimeOffset.UtcNow.UtcTicks - Interlocked.Read(ref _checkedAtTicks) < CacheTtl.Ticks)
+        {
+            status = cached;
+            return true;
+        }
+
+        status = null!;
+        return false;
+    }
+
+    private ArkOperatorStatus Store(ArkOperatorStatus status)
+    {
+        _cached = status;
+        Interlocked.Exchange(ref _checkedAtTicks, DateTimeOffset.UtcNow.UtcTicks);
+        return status;
+    }
+}

--- a/BTCPayServer.Plugins.ArkPayServer/Views/Ark/Receive.cshtml
+++ b/BTCPayServer.Plugins.ArkPayServer/Views/Ark/Receive.cshtml
@@ -29,6 +29,8 @@
     <h1 class="mb-4">@ViewData["Title"]</h1>
 </header>
 
+<partial name="_ArkadeOperatorStatusBanner" />
+
 <form method="post" asp-action="Receive" asp-route-storeId="@storeId">
     @if (!hasAny)
     {

--- a/BTCPayServer.Plugins.ArkPayServer/Views/Ark/Send.cshtml
+++ b/BTCPayServer.Plugins.ArkPayServer/Views/Ark/Send.cshtml
@@ -104,6 +104,7 @@
 </div>
 
 <partial name="_StatusMessage" />
+<partial name="_ArkadeOperatorStatusBanner" />
 
 @if (Model.Errors.Any())
 {

--- a/BTCPayServer.Plugins.ArkPayServer/Views/Ark/Send2.cshtml
+++ b/BTCPayServer.Plugins.ArkPayServer/Views/Ark/Send2.cshtml
@@ -21,6 +21,7 @@
 </div>
 
 <partial name="_StatusMessage" />
+<partial name="_ArkadeOperatorStatusBanner" />
 
 @if (Model.Errors.Any())
 {

--- a/BTCPayServer.Plugins.ArkPayServer/Views/Ark/StoreOverview.cshtml
+++ b/BTCPayServer.Plugins.ArkPayServer/Views/Ark/StoreOverview.cshtml
@@ -16,6 +16,7 @@
 }
 
 <partial name="_StatusMessage" />
+<partial name="_ArkadeOperatorStatusBanner" />
 
 <!-- Top Row: Wallet Info + Service Status -->
 <div class="row g-4 mb-4">

--- a/BTCPayServer.Plugins.ArkPayServer/Views/Ark/Swaps.cshtml
+++ b/BTCPayServer.Plugins.ArkPayServer/Views/Ark/Swaps.cshtml
@@ -59,6 +59,7 @@
 </div>
 
 <partial name="_StatusMessage" />
+<partial name="_ArkadeOperatorStatusBanner" />
 
 @if (Model.Debug)
 {

--- a/BTCPayServer.Plugins.ArkPayServer/Views/Ark/Vtxos.cshtml
+++ b/BTCPayServer.Plugins.ArkPayServer/Views/Ark/Vtxos.cshtml
@@ -63,6 +63,7 @@
 </div>
 
 <partial name="_StatusMessage" />
+<partial name="_ArkadeOperatorStatusBanner" />
 
 <form class="d-flex flex-wrap flex-sm-nowrap align-items-center gap-3 mb-4 col-xxl-8" asp-action="Vtxos" asp-route-storeId="@Model.StoreId" method="get">
     <input asp-for="Count" type="hidden" />

--- a/BTCPayServer.Plugins.ArkPayServer/Views/Shared/_ArkadeOperatorStatusBanner.cshtml
+++ b/BTCPayServer.Plugins.ArkPayServer/Views/Shared/_ArkadeOperatorStatusBanner.cshtml
@@ -1,0 +1,15 @@
+@using BTCPayServer.Plugins.ArkPayServer.Services
+@inject ArkOperatorHealthService ArkOperatorHealth
+@{
+    // Cheap when the operator is up (server-info is cached); a short negative-cache TTL in
+    // the health service keeps a downed operator from costing every page a fresh timeout.
+    var arkStatus = await ArkOperatorHealth.GetStatusAsync(Context.RequestAborted);
+}
+@if (!arkStatus.Available)
+{
+    <div class="alert alert-warning alert-dismissible d-flex align-items-start gap-2 my-3" role="alert">
+        <vc:icon symbol="warning" />
+        <div class="flex-fill min-w-0">@(arkStatus.Error ?? ArkOperatorAvailability.UnavailableMessage)</div>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+}


### PR DESCRIPTION
When the Arkade operator (arkd) is unreachable, plugin pages leaked raw transport errors to merchants — e.g. on the Receive page:

> `Status(StatusCode="Unknown", Detail="Bad gRPC response. HTTP status code: 530")`

This replaces those raw errors with a friendly message and adds a persistent, dismissible status banner so the outage is visible across the main plugin pages.

## What changed

**`Services/ArkOperatorAvailability.cs`** (new) — pure classifier. `IsUnavailable(Exception)` / `IsUnavailable(string)` detect operator-unreachable failures (gRPC transport faults, `Bad gRPC response`, HTTP 5xx from the operator edge like a Cloudflare 530, connection-refused / DNS / timeout) via both exception type and message markers, and map them to one `UnavailableMessage`. Genuine app/validation errors are deliberately **not** swallowed (and `OperationCanceledException` from a browser-abort is excluded).

**`Services/ArkOperatorHealthService.cs`** (new) — singleton that caches operator reachability (15s TTL). A successful `GetServerInfoAsync` is the liveness signal. It caches the **result, not a `Task`** (a faulted cached task would pin "down" forever). Because the underlying transport caches a successful server-info for ~5 min, real operations also feed observed outcomes in via `ReportFailure`/`ReportSuccess`, so the banner flips immediately on a failed action instead of waiting for the cache to expire.

**`Views/Shared/_ArkadeOperatorStatusBanner.cshtml`** (new) — dismissible warning banner, rendered only when the operator is unreachable. Mounted on the main plugin pages: **Overview, Receive, Send, Send2, Vtxos, Swaps**.

**`Controllers/ArkController.cs`** — `DescribeArkError(ex, context)` translates operator catch sites (Receive, Send, balances, UpdateWallet, refresh-intent) to the friendly message and flips the banner; the operator status widget (`_ServiceConnections`) now shows the friendly message instead of the raw gRPC dump.

**`ArkPlugin.cs`** — registers `ArkOperatorHealthService` as a singleton.

## Notes
- Plugin-only change; branched off `master` (independent of the open recovery PR #70). NNark submodule pin unchanged.
- No version bump (per repo convention, version/CHANGELOG bumps are a separate release step).

## Test plan
- [x] `dotnet build BTCPayServer.Plugins.ArkPayServer` — 0 errors.
- [ ] Operator up: no banner; pages behave as before.
- [ ] Operator down (stop arkd / point `ark.json` at a dead URL): banner shows on the listed pages; Receive/Send show the friendly message instead of the raw gRPC error; status widget shows the friendly message.
- [ ] Recovery after operator returns: banner clears within ~15s (or immediately after a successful action).