### PR TITLE
chore: bump SDK to dotnet-sdk master + release v2.2.1

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -53,23 +53,6 @@ jobs:
         run: node submodules/NNark/regtest/regtest.mjs start --profile boltz,delegate
         timeout-minutes: 20
 
-      - name: Expose NBXplorer Postgres on :39372 for BTCPay ServerTester
-        # BTCPay (NBXplorer 2.5+) connects directly to NBXplorer's Postgres DB
-        # (explorer.postgres, default 127.0.0.1:39372) — not just its HTTP API.
-        # denigiri runs nbxplorer against its internal `postgres` container,
-        # which is not published on the host (only nbxplorer's HTTP 32838 is).
-        # Forward host :39372 -> postgres:5432 on the regtest network so the
-        # in-process ServerTester can reach the shared nbxplorer DB (this is
-        # what nigiri used to expose directly).
-        run: |
-          net=$(docker inspect postgres --format '{{range $k,$v := .NetworkSettings.Networks}}{{$k}}{{end}}')
-          docker run -d --name nbx-pg-proxy --network "$net" -p 39372:5432 \
-            alpine/socat tcp-listen:5432,fork,reuseaddr tcp-connect:postgres:5432
-          for i in $(seq 1 15); do
-            docker exec nbx-pg-proxy sh -c 'nc -z localhost 5432' 2>/dev/null && break
-            sleep 1
-          done
-
       - name: Resolve arkd container name
         # The arkd container's name depends on which regtest pin is active.
         # Older pins hardcode `container_name: ark` in docker-compose.arkd-override.yml;

--- a/BTCPayServer.Plugins.ArkPayServer/BTCPayServer.Plugins.ArkPayServer.csproj
+++ b/BTCPayServer.Plugins.ArkPayServer/BTCPayServer.Plugins.ArkPayServer.csproj
@@ -7,7 +7,7 @@
 
         <Product>Arkade - Beta</Product>
         <Description>Programmable money for sovereign business. Easily accept payments through Arkade &amp; Lightning non-custodially without complexity.</Description>
-        <Version>2.2.0</Version>
+        <Version>2.2.1</Version>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
         <GenerateRuntimeConfigDevFile>true</GenerateRuntimeConfigDevFile>

--- a/BTCPayServer.Plugins.ArkPayServer/Views/_ViewImports.cshtml
+++ b/BTCPayServer.Plugins.ArkPayServer/Views/_ViewImports.cshtml
@@ -1,5 +1,6 @@
 @using BTCPayServer.Abstractions.Services
 @using NArk.Hosting
+@using NArk.Swaps.Extensions
 @inject Microsoft.AspNetCore.Mvc.Localization.ViewLocalizer ViewLocalizer
 @inject Microsoft.Extensions.Localization.IStringLocalizer StringLocalizer
 @inject Safe Safe

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [2.2.1] - 2026-06-09
+
+### Features
+- **Wallet recovery on import + manual Rescan (#70).** Importing a wallet now starts background recovery via the SDK's unified `IWalletRecoveryService` — rediscovering contracts (including legacy deprecated-signer scripts), the derivation index, funds, and Boltz swaps, then syncing boarding UTXOs — instead of only polling pre-existing contracts. Adds a `POST stores/{id}/rescan` endpoint and a **Rescan** button on the store overview, with an in-memory `RecoveryStatusTracker` surfacing Running/Completed/Failed per wallet. When the SDK's recovery service isn't registered (no Boltz/swaps configured), recovery degrades to a boarding-only sync.
+
+### SDK (NNark)
+- **Bumped to `arkade-os/dotnet-sdk` master.** Picks up the Boltz swap-logic refactor (#123) and the regtest denigiri Postgres-port pin (#120). The refactor relocated the swap-status helpers (`IsActive`, `IsTerminalState`, `IsSuccess`, …) into `NArk.Swaps.Extensions`; the plugin's Razor views now import that namespace via `_ViewImports.cshtml` so `swap.Status.IsActive()` resolves.
+
 ## [2.2.0] - 2026-05-28
 
 ### Features


### PR DESCRIPTION
## Summary

Bumps the bundled `arkade-os/dotnet-sdk` SDK to its latest `master` and cuts release **v2.2.1**.

### SDK bump
`submodules/NNark` `569bfcf → 4d985df` (dotnet-sdk master), picking up:
- **Boltz swap-logic refactor (#123)** — relocated the swap-status helpers (`IsActive`, `IsTerminalState`, `IsSuccess`, …) into `NArk.Swaps.Extensions`.
- **regtest denigiri Postgres-port pin (#120)**.

Plugin adaptation: the only compile impact was a Razor view (`Swaps.cshtml`) calling `swap.Status.IsActive()`; `_ViewImports.cshtml` now imports `NArk.Swaps.Extensions` so the relocated extensions resolve. No C# changes were needed.

### Release v2.2.1
`<Version>` 2.2.0 → 2.2.1 + CHANGELOG entry covering the changes unreleased since `v2.2.0`:
- **Wallet recovery on import + manual Rescan (#70)** (the one feature on master since the v2.2.0 tag).
- The SDK bump above.

## Test plan
- [x] `dotnet build BTCPayServer.Plugins.ArkPayServer` — clean (0 errors) against the bumped SDK.
- [ ] CI green.
