### PR TITLE
chore: bump SDK (deterministic preimages) + release v2.2.2

### DIFF
--- a/BTCPayServer.Plugins.ArkPayServer/BTCPayServer.Plugins.ArkPayServer.csproj
+++ b/BTCPayServer.Plugins.ArkPayServer/BTCPayServer.Plugins.ArkPayServer.csproj
@@ -7,7 +7,7 @@
 
         <Product>Arkade - Beta</Product>
         <Description>Programmable money for sovereign business. Easily accept payments through Arkade &amp; Lightning non-custodially without complexity.</Description>
-        <Version>2.2.1</Version>
+        <Version>2.2.2</Version>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
         <GenerateRuntimeConfigDevFile>true</GenerateRuntimeConfigDevFile>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [2.2.2] - 2026-06-09
+
+### Features
+- **Greenfield REST API for Arkade wallet operations (#42).** Adds store-scoped, API-key-authenticated `~/api/v1/stores/{storeId}/arkade/*` endpoints covering wallet info / setup / settings, balance, VTXOs, contracts, intents, swaps, send, fee estimation, destination parsing, Boltz limits, and Arkade server info. Reads require `CanViewStoreSettings`; mutations (setup/settings/send) require `CanModifyStoreSettings`. Swap-metadata responses are filtered to a non-sensitive allow-list so chain/reverse-swap secrets (ephemeral key, preimage, Boltz lockup response) are never exposed.
+
+### SDK (NNark)
+- **Bumped to `arkade-os/dotnet-sdk` master — deterministic Boltz preimages (#116).** Reverse and chain swap preimages are now derived deterministically from the wallet's signing key (`SHA-256(BIP-340-sign(key, SHA-256("Arkade-Boltz-Preimage-v1" || xonly_pubkey || u32le(index))))`) instead of random bytes, so a wallet restored from seed/nsec can re-derive the preimage and claim outstanding VHTLCs it rediscovers via Boltz `/v2/swap/restore`. Watch-only/no-signer wallets fall back to a random preimage.
+
 ## [2.2.1] - 2026-06-09
 
 ### Features


### PR DESCRIPTION
## Summary

Bumps the bundled `arkade-os/dotnet-sdk` SDK to its latest `master` and cuts release **v2.2.2**.

### SDK bump
`submodules/NNark` `4d985df → edfdfb9`, bringing **deterministic Boltz preimages (#116)** — reverse/chain swap preimages are derived from the wallet key (`SHA-256(BIP-340-sign(key, SHA-256("Arkade-Boltz-Preimage-v1" || xonly_pubkey || u32le(index))))`) instead of random bytes, so a wallet restored from seed/nsec can re-derive and claim outstanding VHTLCs it rediscovers via Boltz `/v2/swap/restore`. Additive (optional `preimage` params) — no plugin code adaptation needed.

### Release v2.2.2
`<Version>` 2.2.1 → 2.2.2 + CHANGELOG covering what's unreleased since v2.2.1:
- **Greenfield REST API for Arkade wallet operations (#42).**
- The SDK bump above.

## Test plan
- [x] `dotnet build BTCPayServer.Plugins.ArkPayServer` — clean against the bumped SDK.
- [ ] CI green.
