### PR TITLE
chore: bump NNark submodule to 1.0.319-beta

### DIFF
--- a/.claude/skills/running-locally/SKILL.md
+++ b/.claude/skills/running-locally/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: running-locally
+description: Use when asked to run, start, launch, smoke-test, or verify BTCPay Server with the Arkade plugin on a local machine — including standing up the regtest environment (bitcoind, arkd, Boltz, NBXplorer) or confirming a change works in the real app.
+---
+
+# Running BTCPay + Arkade Plugin Locally
+
+Every command below was executed and verified on a cold Windows machine. The app is BTCPay Server (from `submodules/btcpayserver`) with the plugin side-loaded via `DEBUG_PLUGINS`; it serves at **http://localhost:14142**.
+
+## Prerequisites
+
+| Requirement | Verify | Install if missing |
+|---|---|---|
+| .NET 10 SDK | `dotnet --version` → 10.0.x | `winget install Microsoft.DotNet.SDK.10` (new shells only pick up PATH after refresh) |
+| Docker engine running | `docker info` | Start Docker Desktop |
+| Node ≥ 18 | `node --version` | — |
+
+## One-time setup
+
+```powershell
+./setup.ps1   # or ./setup.sh — submodules, workloads, publishes plugin, writes appsettings.dev.json
+```
+
+## Start the regtest stack (~19 containers)
+
+```powershell
+node submodules/NNark/regtest/regtest.mjs start --profile boltz,delegate
+# Windows shortcut: start-test-env.cmd (args pass through: `start-test-env stop`, `... clean`, `... mine 5`)
+```
+
+First run pulls images (several minutes). Do **not** create databases manually — BTCPay and NBXplorer each auto-create their own Postgres DB (the stack's Postgres is trust-auth on port 39372).
+
+## Launch BTCPay Server
+
+The default `Bitcoin` launch profile already matches the stack's ports (NBXplorer 32838, Postgres 39372):
+
+```powershell
+# detached, so it survives the shell; logs land in repo root (gitignored pattern btcpay-run*.log)
+Start-Process dotnet -ArgumentList 'run','-lp','Bitcoin' `
+  -WorkingDirectory 'submodules\btcpayserver\BTCPayServer' `
+  -RedirectStandardOutput btcpay-run.log -RedirectStandardError btcpay-run.err.log -WindowStyle Hidden
+```
+
+First launch builds the whole BTCPay solution — allow ~5 minutes before the port answers.
+
+## Verify
+
+- `http://localhost:14142/login` returns 200 ("Sign in")
+- `http://localhost:14142/api/v1/health` → `{"synchronized":true}`
+- `btcpay-run.log` contains `Running plugin BTCPayServer.Plugins.ArkPayServer`
+- First registered user becomes admin (`ALLOW-ADMIN-REGISTRATION` is on)
+
+## Drive it
+
+- Fund: `node submodules/NNark/regtest/regtest.mjs faucet <address> <btc> --confirm`
+- Mine: `node submodules/NNark/regtest/regtest.mjs mine [n]`
+- Mempool explorer http://localhost:3000 · arkd localhost:7070 (password `secret`) · Arkade web wallet http://localhost:3003
+
+## Stop / iterate
+
+- Stop BTCPay: kill the `dotnet` process. Restart: same `dotnet run -lp Bitcoin`.
+- After plugin code changes: `dotnet publish BTCPayServer.Plugins.ArkPayServer -c Debug -o BTCPayServer.Plugins.ArkPayServer/bin/Debug/net10.0` (what setup.ps1 does), then restart BTCPay.
+- Stack: `regtest.mjs stop` keeps data; `regtest.mjs clean` wipes volumes.
+
+## Common mistakes
+
+- Polling the port too early and concluding startup failed — check `btcpay-run.err.log` for a real error first.
+- Manually running `createdb` — unnecessary, BTCPay/NBXplorer self-provision.
+- Expecting Lightning at checkout — the launch profile's c-lightning endpoint (30993) isn't in this stack; Arkade's Lightning flow goes through Boltz instead.

--- a/.claude/skills/running-locally/SKILL.md
+++ b/.claude/skills/running-locally/SKILL.md
@@ -5,25 +5,25 @@ description: Use when asked to run, start, launch, smoke-test, or verify BTCPay 
 
 # Running BTCPay + Arkade Plugin Locally
 
-Every command below was executed and verified on a cold Windows machine. The app is BTCPay Server (from `submodules/btcpayserver`) with the plugin side-loaded via `DEBUG_PLUGINS`; it serves at **http://localhost:14142**.
+Plain agent-agnostic markdown — usable by any coding agent (it is referenced from AGENTS.md; Claude Code also auto-discovers it as a skill). Every command below was executed and verified on a cold Windows machine; bash equivalents are noted where shells differ. The app is BTCPay Server (from `submodules/btcpayserver`) with the plugin side-loaded via `DEBUG_PLUGINS`; it serves at **http://localhost:14142**.
 
 ## Prerequisites
 
 | Requirement | Verify | Install if missing |
 |---|---|---|
-| .NET 10 SDK | `dotnet --version` → 10.0.x | `winget install Microsoft.DotNet.SDK.10` (new shells only pick up PATH after refresh) |
+| .NET 10 SDK | `dotnet --version` → 10.0.x | `winget install Microsoft.DotNet.SDK.10` on Windows (new shells only pick up PATH after refresh); see dotnet.microsoft.com elsewhere |
 | Docker engine running | `docker info` | Start Docker Desktop |
 | Node ≥ 18 | `node --version` | — |
 
 ## One-time setup
 
-```powershell
-./setup.ps1   # or ./setup.sh — submodules, workloads, publishes plugin, writes appsettings.dev.json
+```sh
+./setup.ps1   # Windows · ./setup.sh on Linux/macOS — submodules, workloads, publishes plugin, writes appsettings.dev.json
 ```
 
 ## Start the regtest stack (~19 containers)
 
-```powershell
+```sh
 node submodules/NNark/regtest/regtest.mjs start --profile boltz,delegate
 # Windows shortcut: start-test-env.cmd (args pass through: `start-test-env stop`, `... clean`, `... mine 5`)
 ```
@@ -32,10 +32,16 @@ First run pulls images (several minutes). Do **not** create databases manually �
 
 ## Launch BTCPay Server
 
-The default `Bitcoin` launch profile already matches the stack's ports (NBXplorer 32838, Postgres 39372):
+The default `Bitcoin` launch profile already matches the stack's ports (NBXplorer 32838, Postgres 39372). Launch detached so it survives the shell; logs land in repo root (gitignored pattern `btcpay-run*.log`).
 
+bash:
+```sh
+(cd submodules/btcpayserver/BTCPayServer && nohup dotnet run -lp Bitcoin \
+  > ../../../btcpay-run.log 2> ../../../btcpay-run.err.log &)
+```
+
+PowerShell:
 ```powershell
-# detached, so it survives the shell; logs land in repo root (gitignored pattern btcpay-run*.log)
 Start-Process dotnet -ArgumentList 'run','-lp','Bitcoin' `
   -WorkingDirectory 'submodules\btcpayserver\BTCPayServer' `
   -RedirectStandardOutput btcpay-run.log -RedirectStandardError btcpay-run.err.log -WindowStyle Hidden
@@ -64,6 +70,7 @@ First launch builds the whole BTCPay solution — allow ~5 minutes before the po
 
 ## Common mistakes
 
+- `nohup: failed to run command 'dotnet'` / `dotnet: command not found` — the shell predates the SDK install; open a new shell or extend PATH (Git Bash: `export PATH="$PATH:/c/Program Files/dotnet"`).
 - Polling the port too early and concluding startup failed — check `btcpay-run.err.log` for a real error first.
 - Manually running `createdb` — unnecessary, BTCPay/NBXplorer self-provision.
 - Expecting Lightning at checkout — the launch profile's c-lightning endpoint (30993) isn't in this stack; Arkade's Lightning flow goes through Boltz instead.

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,6 @@ nigiri/
 nul
 .superpowers
 .playwright-mcp
-.claude/
+.claude/*
+!.claude/skills/
+btcpay-run*.log

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,12 @@ and publishes the plugin (NNark dependencies included). Use
 `./add-migration.sh <Name>` to add EF Core migrations, and `start-test-env.cmd`
 to bring up the local regtest/Arkade test environment.
 
+To run the app locally (regtest stack + BTCPay with the plugin + smoke
+checks), follow the verified recipe in
+[`.claude/skills/running-locally/SKILL.md`](.claude/skills/running-locally/SKILL.md)
+— plain markdown usable by any agent; Claude Code also auto-discovers it
+as a skill.
+
 ## Agent Guidance
 - Follow standard .NET naming conventions.
 - Ensure the solution builds successfully before committing.

--- a/README.md
+++ b/README.md
@@ -204,12 +204,12 @@ The setup script will:
 
 ### Running Tests
 
-After running `setup.sh`, start the local regtest environment (Bitcoin + arkd + Boltz/Fulmine):
+After running `setup.sh`, start the local regtest environment (Bitcoin + arkd + Boltz/Fulmine) — a cross-platform Node CLI, no WSL required:
 ```bash
-./submodules/NNark/regtest/start-env.sh
+node submodules/NNark/regtest/regtest.mjs start --profile boltz,delegate
 ```
 
-On Windows (wraps the same script via WSL):
+On Windows (wraps the same CLI; extra arguments pass through, e.g. `start-test-env stop`):
 ```cmd
 start-test-env.cmd
 ```

--- a/start-test-env.cmd
+++ b/start-test-env.cmd
@@ -1,5 +1,11 @@
 @echo off
 setlocal
-set "SCRIPT_DIR=%~dp0submodules\NNark\regtest"
-set "OVERRIDE_ENV=%~dp0submodules\NNark\.env.regtest"
-wsl -e bash -c "cd \"$(wslpath '%SCRIPT_DIR%')\" && if [ -f \"$(wslpath '%OVERRIDE_ENV%')\" ]; then sed -i 's/\r$//' \"$(wslpath '%OVERRIDE_ENV%')\"; fi && sed 's/\r$//' start-env.sh | bash -s -- --clean"
+rem Wrapper around the NNark regtest CLI (cross-platform Node orchestrator,
+rem no WSL required). No arguments starts the full BTCPay-relevant stack;
+rem any arguments are passed through (e.g. `start-test-env stop`,
+rem `start-test-env clean`, `start-test-env mine 5`).
+if "%~1"=="" (
+    node "%~dp0submodules\NNark\regtest\regtest.mjs" start --profile boltz,delegate
+) else (
+    node "%~dp0submodules\NNark\regtest\regtest.mjs" %*
+)


### PR DESCRIPTION
## Summary

Bumps the NNark (dotnet-sdk) submodule pin from `NArk.Abstractions/1.0.314-beta` (`4d985df`) to `1.0.319-beta` (`c8a3fd9`), pulling in:

- fix(core): limit vtxos per intent to 50 (arkade-os/dotnet-sdk#125)
- fix: add ECXOnlyPubKeyComparer (arkade-os/dotnet-sdk#127)
- feat(swaps): deterministic Boltz preimages via BIP-340 sign-and-hash (arkade-os/dotnet-sdk#116)
- test(e2e): close boarding-confirmation flake in settle pipeline tests (arkade-os/dotnet-sdk#129)
- test(e2e): gate Fulmine liquidity on spendable VTXOs, recover via settle (arkade-os/dotnet-sdk#130)

## Test plan

- [x] Plugin builds clean against the new pin
- [x] SDK's full E2E suite verified 50/50 green at exactly `c8a3fd9` on the local regtest stack
- [ ] CI green
