### PR TITLE
feat: arkd signer-rotation support (SDK bump + thin plugin)

### DIFF
--- a/BTCPayServer.Plugins.ArkPayServer/BTCPayServer.Plugins.ArkPayServer.csproj
+++ b/BTCPayServer.Plugins.ArkPayServer/BTCPayServer.Plugins.ArkPayServer.csproj
@@ -7,7 +7,7 @@
 
         <Product>Arkade - Beta</Product>
         <Description>Programmable money for sovereign business. Easily accept payments through Arkade &amp; Lightning non-custodially without complexity.</Description>
-        <Version>2.2.1</Version>
+        <Version>2.3.0</Version>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
         <GenerateRuntimeConfigDevFile>true</GenerateRuntimeConfigDevFile>

--- a/BTCPayServer.Plugins.ArkPayServer/Controllers/ArkController.cs
+++ b/BTCPayServer.Plugins.ArkPayServer/Controllers/ArkController.cs
@@ -76,6 +76,7 @@ public class ArkController(
     ISpendingService arkadeSpender,
     IFeeEstimator feeEstimator,
     IContractService contractService,
+    NArk.Core.Recovery.ISingleKeyDefaultEnsurer singleKeyDefaultEnsurer,
     IBitcoinBlockchain bitcoinTimeChainProvider,
     VtxoSynchronizationService vtxoSyncService,
     IContractStorage contractStorage,
@@ -158,12 +159,11 @@ public class ArkController(
 
                     if (wallet.WalletType == WalletType.SingleKey)
                     {
-                       await  contractService.DeriveContract(
-                           wallet.Id,
-                           NextContractPurpose.SendToSelf,
-                           ContractActivityState.Active,
-                           metadata: new Dictionary<string, string> { ["Source"] = "Default" },
-                           cancellationToken: HttpContext.RequestAborted);
+                        // Synchronous default-contract creation at setup (no regression vs. the
+                        // prior inline DeriveContract), but the "how" now lives in the SDK. The
+                        // persisted Default is thereafter maintained across signer rotation by
+                        // the SDK's ContractReconciliationService (started via ArkHostedLifecycle).
+                        await singleKeyDefaultEnsurer.EnsureDefaultAsync(wallet.Id, HttpContext.RequestAborted);
                     }
 
                     walletSettings = walletSettings with { WalletId = wallet.Id };
@@ -331,7 +331,9 @@ public class ArkController(
         string? defaultAddress = null;
         if (wallet?.WalletType == WalletType.SingleKey)
         {
-            // SingleKey: compute the deterministic default address directly from the wallet key
+            // SingleKey: compute the deterministic default address directly from the wallet key.
+            // This is recomputed from the CURRENT signer, which matches the persisted Default
+            // maintained by the SDK ContractReconciliationService — so display == watched holds.
             var terms = await clientTransport.GetServerInfoAsync(cancellationToken);
             var descriptor = OutputDescriptor.Parse(wallet.AccountDescriptor, terms.Network);
             var defaultContract = new ArkPaymentContract(terms.SignerKey, terms.UnilateralExit, descriptor);

--- a/BTCPayServer.Plugins.ArkPayServer/Controllers/ArkGreenfieldController.cs
+++ b/BTCPayServer.Plugins.ArkPayServer/Controllers/ArkGreenfieldController.cs
@@ -56,6 +56,7 @@ public class ArkGreenfieldController(
     ISpendingService arkadeSpender,
     IFeeEstimator feeEstimator,
     IContractService contractService,
+    NArk.Core.Recovery.ISingleKeyDefaultEnsurer singleKeyDefaultEnsurer,
     IBitcoinBlockchain bitcoinTimeChainProvider,
     VtxoSynchronizationService vtxoSyncService,
     IContractStorage contractStorage,
@@ -143,12 +144,10 @@ public class ArkGreenfieldController(
 
                 if (walletInfo.WalletType == WalletType.SingleKey)
                 {
-                    await contractService.DeriveContract(
-                        walletInfo.Id,
-                        NextContractPurpose.SendToSelf,
-                        ContractActivityState.Active,
-                        metadata: new Dictionary<string, string> { ["Source"] = "Default" },
-                        cancellationToken: cancellationToken);
+                    // Delegate to the SDK's ensurer (destination-insensitive, unlike the
+                    // SendToSelf path); the SDK ContractReconciliationService also maintains
+                    // this default across signer rotation.
+                    await singleKeyDefaultEnsurer.EnsureDefaultAsync(walletInfo.Id, cancellationToken);
                 }
 
                 walletId = walletInfo.Id;

--- a/BTCPayServer.Plugins.ArkPayServer/ViewComponents/ArkDashboardWidgetViewComponent.cs
+++ b/BTCPayServer.Plugins.ArkPayServer/ViewComponents/ArkDashboardWidgetViewComponent.cs
@@ -86,6 +86,8 @@ public class ArkDashboardWidgetViewComponent(
 
                         if (terms != null)
                         {
+                            // Recomputed from the CURRENT signer, which matches the persisted
+                            // Default maintained by the SDK ContractReconciliationService.
                             var descriptor = OutputDescriptor.Parse(wallet.AccountDescriptor, terms.Network);
                             var defaultContract = new ArkPaymentContract(terms.SignerKey, terms.UnilateralExit, descriptor);
                             model.DefaultAddress = defaultContract.GetArkAddress()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [2.3.0] - 2026-06-13
+
+### Features
+- **arkd signer-key rotation support (#78).** When an Arkade operator rotates its signing key, a wallet's existing contracts and Arkade addresses (derived from the *server* signer key) go stale. The plugin now keeps the SingleKey **"Default"** receive contract aligned with the operator's current signer automatically: store setup and Greenfield wallet creation delegate to the SDK's `EnsureDefaultAsync`, and the store overview reads the SDK's reconciled Default directly instead of re-deriving it. The rotation mechanism itself is SDK-owned (see below), so the plugin stays a thin BTCPay adapter — no plugin-side polling or migration code; funds under a superseded signer are swept, held, or re-enrolled by the SDK's hosted services.
+
+### SDK (NNark)
+- **Bumped to `arkade-os/dotnet-sdk` master @ `309885d` (#132)** — brings in the full signer-rotation mechanism and supporting work.
+- **Reconciliation & discovery.** `ContractReconciliationService` realigns each SingleKey wallet's Default to the current signer on startup, `WalletSaved`, and rotation; `SingleKeyVtxoRecoveryService` rediscovers VTXOs across the `{current ∪ deprecated}` signer set so funds stranded under a rotated key are recovered.
+- **Detection.** Rotation is detected through the `ServerInfoChanged` event — both mid-request (`DIGEST_MISMATCH`) and on the 5-minute server-info TTL refresh — rather than polling.
+- **Three fund regimes.** Before the cutoff, deprecated-signer VTXOs are collaboratively swept onto the current signer (`ServerKeyRotationSweepPolicy`); after the cutoff a coin can no longer be spent offchain nor selected into a batch while it still needs a forfeit (it would brick the whole intent); after expiry it re-enrolls forfeit-free under the current signer.
+- **Transport hardening (#134).** `DIGEST_MISMATCH` / `BUILD_VERSION_TOO_OLD` are now translated mid-stream on server-streaming and duplex RPCs (`GuardedStreamReader`), `ServerInfoChanged` dispatch is deferred past the lock to avoid a re-entrant deadlock, and the caching transport is registered as a concrete singleton aliased to both `IClientTransport` and `IServerInfoCacheInvalidation` (no unsafe cast).
+- **Headers & E2E baseline.** Every gRPC/REST request carries `X-Build-Version` and `X-Digest`; the E2E stack moved to arkd **v0.9.9-rc.1** with a deprecated signer pre-configured so the rotation sweeper runs in CI.
+- Plus master changes since the last bump: a 50-VTXO-per-intent cap (#125), `ECXOnlyPubKeyComparer` (#127), and E2E stabilization (#129, #130).
+
 ## [2.2.1] - 2026-06-09
 
 ### Features


### PR DESCRIPTION
## Summary

Adds arkd **signer-key rotation** handling to the Arkade plugin. When the operator rotates its signing key, a wallet's existing contracts/addresses remain derived under the old key; this keeps each SingleKey wallet's Default aligned with the current signer, discovers funds stranded under deprecated signers, and migrates them.

The rotation mechanism is **SDK-owned** (it's generic Arkade wallet behavior). This PR bumps the NArk submodule to that work and makes the thin plugin-side changes. Rebased onto current master (after #76/#77).

## ⚠️ Stacked on arkade-os/dotnet-sdk#132

`submodules/NNark` points at the SDK branch `feat/signer-rotation-support` (`bc5ef1e`, unmerged). Merge **after** #132 lands, then re-point the submodule to the merged `master` commit. (#132 itself carries dotnet-sdk #131 + #126.)

## SDK side (via the bump — see #132)

- `ContractReconciliationService` (hosted): on `WalletSaved` / `ServerInfoChanged` / startup, ensures each SingleKey wallet's current-signer Default and supersedes stale ones.
- SingleKey deprecated-signer discovery; `EnsureDefaultAsync` (B2 fix); `ServerInfoChanged` detection event (off #131's digest invalidation); carries #126's sweep policy.

## Plugin side (this repo)

- Setup delegates SingleKey default-creation to the SDK's `EnsureDefaultAsync` (no more inline `DeriveContract`).
- Reconciliation runs in the BTCPay host automatically — `ArkPlugin` already registers the SDK via `AddArkCoreServices()` (which includes the reconciliation service + `ArkHostedLifecycle`); no extra wiring needed.
- Store Overview / dashboard default-address display is unchanged: it already recomputes from the current `SignerKey`, which now matches the SDK-reconciled persisted Default (display == watched).
- Design spec + implementation plan under `docs/superpowers/`.

## Funds model (3 regimes)

A deprecated-signer VTXO: before cutoff → collaboratively swept under the current signer (#126); after cutoff, before VTXO expiry → waits (operator refuses the old key); after expiry → re-enrolls into a batch under the current signer via the existing intent scheduler (no old key needed). Coin-gathering is keyed on VTXO **script**, not contract Active-state, so deactivating a stale default never strands funds.

## Tests

SDK `NArk.Tests`: 524 passing. Plugin builds clean (0 errors). Rotation E2E to follow.