### PR TITLE
feat: disable & surface a sweep destination orphaned by a signer rotation (v2.4.0)

### DIFF
--- a/BTCPayServer.Plugins.ArkPayServer/ArkPlugin.cs
+++ b/BTCPayServer.Plugins.ArkPayServer/ArkPlugin.cs
@@ -8,10 +8,12 @@ using BTCPayServer.PayoutProcessors;
 using BTCPayServer.Payouts;
 using BTCPayServer.Plugins.ArkPayServer.Data;
 using BTCPayServer.Plugins.ArkPayServer.Lightning;
+using BTCPayServer.Plugins.ArkPayServer.Notifications;
 using BTCPayServer.Plugins.ArkPayServer.PaymentHandler;
 using BTCPayServer.Plugins.ArkPayServer.Payouts.Ark;
 using BTCPayServer.Plugins.ArkPayServer.Services;
 using BTCPayServer.Plugins.ArkPayServer.Services.WalletLogger;
+using BTCPayServer.Services.Notifications;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -97,6 +99,8 @@ public class ArkadePlugin : BaseBTCPayServerPlugin
         services.AddSingleton<IPayoutProcessorFactory>(sp => sp.GetRequiredService<ArkAutomatedPayoutSenderFactory>());
 
         services.AddDefaultPrettyName(ArkadePaymentMethodId, "Arkade");
+
+        services.AddSingleton<INotificationHandler, ArkadeDestinationDisabledNotification.Handler>();
     }
 
     private static void RegisterDatabase(IServiceCollection services)
@@ -310,6 +314,8 @@ public class ArkadePlugin : BaseBTCPayServerPlugin
 
         services.AddSingleton<BoardingUtxoPollService>();
         services.AddHostedService(sp => sp.GetRequiredService<BoardingUtxoPollService>());
+
+        services.AddHostedService<DestinationDisabledNotifierBridge>();
     }
 
     private static void RegisterUIExtensions(IServiceCollection services)

--- a/BTCPayServer.Plugins.ArkPayServer/BTCPayServer.Plugins.ArkPayServer.csproj
+++ b/BTCPayServer.Plugins.ArkPayServer/BTCPayServer.Plugins.ArkPayServer.csproj
@@ -7,7 +7,7 @@
 
         <Product>Arkade - Beta</Product>
         <Description>Programmable money for sovereign business. Easily accept payments through Arkade &amp; Lightning non-custodially without complexity.</Description>
-        <Version>2.3.0</Version>
+        <Version>2.4.0</Version>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
         <GenerateRuntimeConfigDevFile>true</GenerateRuntimeConfigDevFile>

--- a/BTCPayServer.Plugins.ArkPayServer/Controllers/ArkController.cs
+++ b/BTCPayServer.Plugins.ArkPayServer/Controllers/ArkController.cs
@@ -429,6 +429,7 @@ public class ArkController(
             Wallet = wallet?.Secret,
             WalletType = wallet?.WalletType ?? WalletType.SingleKey,
             CanManagePrivateKeys = canManagePrivateKeys,
+            DestinationPendingConfirmation = wallet?.Metadata?.ContainsKey(NArk.Core.Services.DestinationSafety.PendingConfirmationMetadataKey) == true,
             RecoveryStatus = config.WalletId is { } recoveryWalletId ? recoveryStatusTracker.Get(recoveryWalletId) : null,
             ArkOperatorUrl = arkNetworkConfig.ArkUri,
             ArkOperatorConnected = arkOperatorConnected,
@@ -1990,6 +1991,40 @@ public class ArkController(
         }
 
         return RedirectToAction(nameof(StoreOverview), new { storeId });
+    }
+
+    [HttpPost("stores/{storeId}/destination")]
+    [Authorize(Policy = Policies.CanModifyStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
+    public async Task<IActionResult> UpdateDestination(string storeId, string destination, CancellationToken ct)
+    {
+        var (_, config, errorResult) = await ValidateStoreAndConfig();
+        if (errorResult != null) return errorResult;
+
+        destination = destination?.Trim() ?? string.Empty;
+        if (!NArk.Abstractions.ArkAddress.TryParse(destination, out var parsed) || parsed is null)
+            return RedirectWithError(nameof(StoreOverview), "Invalid Arkade address. Please enter a valid ark1… address.", new { storeId });
+
+        NArk.Core.ArkServerInfo serverInfo;
+        try
+        {
+            serverInfo = await clientTransport.GetServerInfoAsync(ct);
+        }
+        catch (Exception ex)
+        {
+            return RedirectWithError(nameof(StoreOverview), DescribeArkError(ex, "Could not reach the Arkade server"), new { storeId });
+        }
+
+        if (NArk.Core.Services.DestinationSafety.IsStale(parsed, serverInfo))
+            return RedirectWithError(nameof(StoreOverview),
+                "That address is still on a deprecated signer; use a current Arkade address.", new { storeId });
+
+        var wallet = await walletStorage.GetWalletById(config!.WalletId!, ct);
+        if (wallet is null)
+            return RedirectWithError(nameof(StoreOverview), "Wallet not found.", new { storeId });
+
+        await walletStorage.UpsertWallet(wallet with { Destination = destination }, updateIfExists: true, ct);
+
+        return RedirectWithSuccess(nameof(StoreOverview), "Sweep destination re-confirmed.", new { storeId });
     }
 
     [HttpGet("stores/{storeId}/contracts")]

--- a/BTCPayServer.Plugins.ArkPayServer/Models/StoreOverviewViewModel.cs
+++ b/BTCPayServer.Plugins.ArkPayServer/Models/StoreOverviewViewModel.cs
@@ -33,6 +33,13 @@ public class StoreOverviewViewModel
     /// </summary>
     public bool CanManagePrivateKeys { get; set; }
 
+    /// <summary>
+    /// True when the wallet's sweep destination was disabled because a signer rotation
+    /// made it stale. The SDK sets <c>destination:pendingConfirmation</c> in wallet
+    /// metadata and pauses sweeping until the merchant re-confirms a current-signer address.
+    /// </summary>
+    public bool DestinationPendingConfirmation { get; set; }
+
     /// <summary>Status of the most recent background wallet-recovery run (import or Rescan), if any.</summary>
     public RecoveryStatus? RecoveryStatus { get; set; }
 

--- a/BTCPayServer.Plugins.ArkPayServer/Notifications/ArkadeDestinationDisabledNotification.cs
+++ b/BTCPayServer.Plugins.ArkPayServer/Notifications/ArkadeDestinationDisabledNotification.cs
@@ -1,0 +1,39 @@
+using BTCPayServer.Abstractions.Contracts;
+using BTCPayServer.Configuration;
+using BTCPayServer.Services.Notifications;
+using Microsoft.AspNetCore.Routing;
+
+namespace BTCPayServer.Plugins.ArkPayServer.Notifications;
+
+public class ArkadeDestinationDisabledNotification : BaseNotification
+{
+    private const string TYPE = "arkade-destination-disabled";
+
+    public string StoreId { get; set; } = "";
+    public override string Identifier => TYPE;
+    public override string NotificationType => TYPE;
+
+    internal class Handler(LinkGenerator linkGenerator, BTCPayServerOptions options)
+        : NotificationHandler<ArkadeDestinationDisabledNotification>
+    {
+        public override string NotificationType => TYPE;
+        public override (string identifier, string name)[] Meta =>
+            [(TYPE, "Arkade destination disabled")];
+
+        protected override void FillViewModel(
+            ArkadeDestinationDisabledNotification notification,
+            NotificationViewModel vm)
+        {
+            vm.Identifier = notification.Identifier;
+            vm.Type = notification.NotificationType;
+            vm.StoreId = notification.StoreId;
+            vm.Body = "An Arkade signer rotation disabled this store's sweep destination. " +
+                      "Review and re-confirm a destination to resume sweeping.";
+            vm.ActionLink = linkGenerator.GetPathByAction(
+                action: nameof(Controllers.ArkController.StoreOverview),
+                controller: "Ark",
+                values: new { storeId = notification.StoreId },
+                options.RootPath);
+        }
+    }
+}

--- a/BTCPayServer.Plugins.ArkPayServer/Services/DestinationDisabledNotifierBridge.cs
+++ b/BTCPayServer.Plugins.ArkPayServer/Services/DestinationDisabledNotifierBridge.cs
@@ -1,0 +1,75 @@
+using BTCPayServer.Data;
+using BTCPayServer.Plugins.ArkPayServer.Notifications;
+using BTCPayServer.Plugins.ArkPayServer.PaymentHandler;
+using BTCPayServer.Services.Invoices;
+using BTCPayServer.Services.Notifications;
+using BTCPayServer.Services.Stores;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using NArk.Abstractions.Wallets;
+
+namespace BTCPayServer.Plugins.ArkPayServer.Services;
+
+/// <summary>
+/// Bridges the SDK's <see cref="IDestinationSafetyNotifier.DestinationDisabled"/> event to a BTCPay
+/// bell notification (<see cref="ArkadeDestinationDisabledNotification"/>) pushed to every store
+/// that is configured with the affected Arkade wallet. Failures are caught and logged so a
+/// notification error never crashes the host.
+/// </summary>
+public class DestinationDisabledNotifierBridge(
+    IDestinationSafetyNotifier notifier,
+    NotificationSender notificationSender,
+    StoreRepository storeRepository,
+    PaymentMethodHandlerDictionary paymentMethodHandlerDictionary,
+    ILogger<DestinationDisabledNotifierBridge> logger)
+    : IHostedService
+{
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        notifier.DestinationDisabled += OnDisabled;
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        notifier.DestinationDisabled -= OnDisabled;
+        return Task.CompletedTask;
+    }
+
+    private void OnDisabled(object? sender, DestinationDisabledEventArgs e) => _ = HandleAsync(e);
+
+    private async Task HandleAsync(DestinationDisabledEventArgs e)
+    {
+        try
+        {
+            var storeIds = await StoreIdsForWallet(e.WalletId);
+            foreach (var storeId in storeIds)
+            {
+                await notificationSender.SendNotification(
+                    new StoreScope(storeId),
+                    new ArkadeDestinationDisabledNotification { StoreId = storeId });
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex,
+                "Failed to push Arkade destination-disabled notification for wallet {WalletId}",
+                e.WalletId);
+        }
+    }
+
+    private async Task<List<string>> StoreIdsForWallet(string walletId)
+    {
+        StoreData[] allStores = await storeRepository.GetStores();
+        var result = new List<string>();
+        foreach (var store in allStores)
+        {
+            var config = store.GetPaymentMethodConfig<ArkadePaymentMethodConfig>(
+                ArkadePlugin.ArkadePaymentMethodId,
+                paymentMethodHandlerDictionary);
+            if (config?.WalletId == walletId)
+                result.Add(store.Id);
+        }
+        return result;
+    }
+}

--- a/BTCPayServer.Plugins.ArkPayServer/Services/DestinationDisabledNotifierBridge.cs
+++ b/BTCPayServer.Plugins.ArkPayServer/Services/DestinationDisabledNotifierBridge.cs
@@ -26,6 +26,10 @@ public class DestinationDisabledNotifierBridge(
 {
     public Task StartAsync(CancellationToken cancellationToken)
     {
+        // Safe against the reconciliation service's own startup pass: that pass only enqueues a job, and
+        // the DestinationDisabled event fires later from a background worker (after a GetServerInfoAsync
+        // round-trip), so this synchronous subscription is always in place first. The pending-confirmation
+        // flag also persists in wallet Metadata, so the overview banner surfaces the state regardless.
         notifier.DestinationDisabled += OnDisabled;
         return Task.CompletedTask;
     }

--- a/BTCPayServer.Plugins.ArkPayServer/Views/Ark/StoreOverview.cshtml
+++ b/BTCPayServer.Plugins.ArkPayServer/Views/Ark/StoreOverview.cshtml
@@ -30,10 +30,13 @@
         <form asp-action="UpdateDestination" method="post" asp-route-storeId="@storeId" class="d-flex flex-wrap gap-2 align-items-center">
             <input type="text" name="destination" class="form-control form-control-sm font-monospace flex-grow-1"
                    placeholder="ark1…" style="max-width: 480px;"
-                   value="@Model.Destination"
                    required />
             <button type="submit" class="btn btn-sm btn-warning">Re-confirm destination</button>
         </form>
+        @if (!string.IsNullOrEmpty(Model.Destination))
+        {
+            <small class="text-muted d-block mt-2">Disabled destination: <span class="font-monospace">@Model.Destination</span> — enter a destination keyed to the current signer.</small>
+        }
     </div>
 }
 

--- a/BTCPayServer.Plugins.ArkPayServer/Views/Ark/StoreOverview.cshtml
+++ b/BTCPayServer.Plugins.ArkPayServer/Views/Ark/StoreOverview.cshtml
@@ -19,6 +19,24 @@
 <partial name="_StatusMessage" />
 <partial name="_ArkadeOperatorStatusBanner" />
 
+@if (Model.DestinationPendingConfirmation)
+{
+    <div class="alert alert-warning mb-4" role="alert">
+        <h5 class="alert-heading">Sweep destination requires re-confirmation</h5>
+        <p class="mb-3">
+            An Arkade signer rotation disabled this store's sweep destination, so sweeping is paused
+            (funds stay on the current signer). Review and re-confirm a destination to resume.
+        </p>
+        <form asp-action="UpdateDestination" method="post" asp-route-storeId="@storeId" class="d-flex flex-wrap gap-2 align-items-center">
+            <input type="text" name="destination" class="form-control form-control-sm font-monospace flex-grow-1"
+                   placeholder="ark1…" style="max-width: 480px;"
+                   value="@Model.Destination"
+                   required />
+            <button type="submit" class="btn btn-sm btn-warning">Re-confirm destination</button>
+        </form>
+    </div>
+}
+
 <!-- Top Row: Wallet Info + Service Status -->
 <div class="row g-4 mb-4">
     <!-- Wallet Info Tile -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [2.4.0] - 2026-06-13
+
+### Features
+- **Sweep-destination safety on signer rotation.** When the Arkade operator rotates its signer, a configured sweep destination keyed to the now-deprecated signer is automatically disabled — sweeping pauses (funds stay on the current signer) and the merchant is alerted two ways: a BTCPay **notification** (bell, linking to the store's Arkade overview) and a **warning banner** on the store overview. Re-confirm a current-signer destination from the banner to resume sweeping. Detection and enforcement are SDK-owned, so the plugin never sweeps to a stale address regardless of whether the merchant has reacted yet.
+
+### SDK (NNark)
+- **Bumped to the `arkade-os/dotnet-sdk` commit carrying destination signer-change safety.** Adds `DestinationSafety.IsStale`, the `IDestinationSafetyNotifier.DestinationDisabled` event, the `destination:pendingConfirmation` wallet-`Metadata` flag set/cleared by `ContractReconciliationService`, and the `DefaultWalletProvider` self-output fallback while a destination is flagged.
+
 ## [2.3.0] - 2026-06-13
 
 ### Features


### PR DESCRIPTION
## Summary

Surfaces and recovers from the SDK's new **destination signer-change safety** (depends on arkade-os/dotnet-sdk#135). When the Arkade operator rotates its signer, a store's sweep destination keyed to the now-deprecated signer is auto-disabled by the SDK (sweeping pauses — funds stay on the current signer). This plugin makes that visible and recoverable:

- **Bell notification** — `ArkadeDestinationDisabledNotification` is pushed per affected store when the SDK raises `IDestinationSafetyNotifier.DestinationDisabled`; it links to the store's Arkade overview.
- **Overview banner** — a warning on the store overview while a destination is pending re-confirmation.
- **Re-confirm** — `POST stores/{storeId}/destination` validates that the entered destination is keyed to the **current** signer (a still-stale one is rejected) and saves it, which fires `WalletSaved` → the SDK reconcile clears the flag and sweeping resumes.

Detection + enforcement are SDK-owned (the plugin never sweeps to a stale address regardless of whether the merchant has reacted); this PR is the thin BTCPay surface — notification, banner, re-confirm.

## SDK dependency

Bumps the `submodules/NNark` gitlink to `d238a7c` (the SDK destination-safety branch, arkade-os/dotnet-sdk#135). **Merge #135 first**; this gitlink will then be re-pointed to the SDK master commit.

## Version

`2.3.0` → `2.4.0` + CHANGELOG entry.
