### PR TITLE
fix: resolve CSRF errors caused by nested HTML forms

### DIFF
--- a/BTCPayServer.Plugins.ArkPayServer/Views/Ark/Contracts.cshtml
+++ b/BTCPayServer.Plugins.ArkPayServer/Views/Ark/Contracts.cshtml
@@ -396,35 +396,33 @@
                                             </h5>
                                             <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
                                         </div>
-                                        <form asp-action="DeleteContract" method="post" asp-route-storeId="@storeId" asp-route-script="@contract.Script">
-                                            <div class="modal-body">
-                                                <div class="alert alert-danger">
-                                                    <strong>Warning:</strong> This action cannot be undone.
-                                                </div>
-                                                <p class="mb-3">Are you sure you want to delete this contract?</p>
-                                                <div class="mb-3">
-                                                    <label class="text-muted small">Contract Address</label>
-                                                    <div class="font-monospace small text-break">@addressStr</div>
-                                                </div>
-                                                <div class="mb-3">
-                                                    <label class="text-muted small">Contract Type</label>
-                                                    <div>@contract.Type</div>
-                                                </div>
-                                                if (hasSwaps)
-                                                {
-                                                    <div class="alert alert-info">
-                                                        <strong>Note:</strong> This contract has swap history. Deleting will remove all swap records.
-                                                    </div>
-                                                }
-                                                <p class="text-muted mb-0">
-                                                    Deleting this contract will remove it from your wallet. This action cannot be undone.
-                                                </p>
+                                        <div class="modal-body">
+                                            <div class="alert alert-danger">
+                                                <strong>Warning:</strong> This action cannot be undone.
                                             </div>
-                                            <div class="modal-footer">
-                                                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-                                                <button type="submit" class="btn btn-danger">Delete Contract</button>
+                                            <p class="mb-3">Are you sure you want to delete this contract?</p>
+                                            <div class="mb-3">
+                                                <label class="text-muted small">Contract Address</label>
+                                                <div class="font-monospace small text-break">@addressStr</div>
                                             </div>
-                                        </form>
+                                            <div class="mb-3">
+                                                <label class="text-muted small">Contract Type</label>
+                                                <div>@contract.Type</div>
+                                            </div>
+                                            @if (hasSwaps)
+                                            {
+                                                <div class="alert alert-info">
+                                                    <strong>Note:</strong> This contract has swap history. Deleting will remove all swap records.
+                                                </div>
+                                            }
+                                            <p class="text-muted mb-0">
+                                                Deleting this contract will remove it from your wallet. This action cannot be undone.
+                                            </p>
+                                        </div>
+                                        <div class="modal-footer">
+                                            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                                            <button type="button" class="btn btn-danger delete-contract-confirm-btn" data-script="@contract.Script">Delete Contract</button>
+                                        </div>
                                     </div>
                                 </div>
                             </div>
@@ -489,20 +487,29 @@ else
 
 <partial name="_HtlcCountdownScript" />
 
-@* Sync Contract Form (outside main form to avoid nested form issues) *@
+@* Forms outside main form to avoid nested form issues *@
 <form id="syncContractForm" asp-action="SyncContract" method="post" asp-route-storeId="@storeId" style="display: none;">
     <input type="hidden" name="script" id="syncContractScript" />
+</form>
+<form id="deleteContractForm" asp-action="DeleteContract" method="post" asp-route-storeId="@storeId" style="display: none;">
+    <input type="hidden" name="script" id="deleteContractScript" />
 </form>
 
 @section PageFootContent {
     <script>
         document.addEventListener('DOMContentLoaded', function() {
-            // Handle sync contract button clicks
             document.querySelectorAll('.sync-contract-btn').forEach(function(btn) {
                 btn.addEventListener('click', function() {
                     var script = this.getAttribute('data-script');
                     document.getElementById('syncContractScript').value = script;
                     document.getElementById('syncContractForm').submit();
+                });
+            });
+            document.querySelectorAll('.delete-contract-confirm-btn').forEach(function(btn) {
+                btn.addEventListener('click', function() {
+                    var script = this.getAttribute('data-script');
+                    document.getElementById('deleteContractScript').value = script;
+                    document.getElementById('deleteContractForm').submit();
                 });
             });
         });

--- a/BTCPayServer.Plugins.ArkPayServer/Views/Ark/Swaps.cshtml
+++ b/BTCPayServer.Plugins.ArkPayServer/Views/Ark/Swaps.cshtml
@@ -264,11 +264,9 @@
                             <td class="align-middle text-end">
                                 @if (swap.Status.IsActive())
                                 {
-                                    <form asp-action="PollSwap" asp-route-storeId="@Model.StoreId" asp-route-swapId="@swap.SwapId" method="post" class="d-inline">
-                                        <button type="submit" class="btn btn-link p-0 text-secondary" title="Manually poll swap status" data-bs-toggle="tooltip">
-                                            <vc:icon symbol="actions-refresh" />
-                                        </button>
-                                    </form>
+                                    <button type="submit" form="poll-form-@swap.SwapId.GetHashCode()" class="btn btn-link p-0 text-secondary" title="Manually poll swap status" data-bs-toggle="tooltip">
+                                        <vc:icon symbol="actions-refresh"/>
+                                    </button>
                                 }
                             </td>
                         </tr>
@@ -279,6 +277,11 @@
     </form>
 
     <vc:pager view-model="Model" />
+
+    @foreach (var swap in Model.Swaps.Where(s => s.Status.IsActive()))
+    {
+        <form id="poll-form-@swap.SwapId.GetHashCode()" asp-action="PollSwap" asp-route-storeId="@Model.StoreId" asp-route-swapId="@swap.SwapId" method="post" style="display:none;"></form>
+    }
 }
 else
 {


### PR DESCRIPTION
## Summary
- Swaps.cshtml - The per-swap "Poll Status" refresh button was inside a <form> nested within the outer MassActionSwaps form. HTML5 ignores inner <form> start tags but processes inner </form> end tags, which closed the outer form early — leaving the poll button outside any form and causing requests to be sent without a CSRF token. Fixed by moving the PollSwap forms outside the main form and associating each button via the HTML form="..." attribute.
- Contracts.cshtml - The DeleteContract form was nested inside the MassActionContracts form (via Bootstrap modal in <tbody>), the same class of bug. Fixed by removing the inline form from the modal, extracting a single shared deleteContractForm outside the main form (same pattern as the existing syncContractForm), and wiring the confirm button via JS + data-script.