### PR TITLE
chore: bump NArk to 0.9.9 build-version + rotation E2E (plugin 2.4.1)

### DIFF
--- a/BTCPayServer.Plugins.ArkPayServer/BTCPayServer.Plugins.ArkPayServer.csproj
+++ b/BTCPayServer.Plugins.ArkPayServer/BTCPayServer.Plugins.ArkPayServer.csproj
@@ -7,7 +7,7 @@
 
         <Product>Arkade - Beta</Product>
         <Description>Programmable money for sovereign business. Easily accept payments through Arkade &amp; Lightning non-custodially without complexity.</Description>
-        <Version>2.4.0</Version>
+        <Version>2.4.1</Version>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
         <GenerateRuntimeConfigDevFile>true</GenerateRuntimeConfigDevFile>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.4.1] - 2026-06-14
+
+### SDK (NNark)
+- **Bumped to `arkade-os/dotnet-sdk` master @ `29d92af` (#137).** Raises the `X-Build-Version` the SDK reports to arkd from `0.9.7` to `0.9.9` (matching arkd `v0.9.9`). Also adds real-rotation end-to-end test coverage on the SDK side (destination-disable, within-cutoff sweep migration, past-cutoff held-back, driven by arkade-regtest's `rotate-signer`) — test-only, no plugin-runtime change.
+
 ## [2.4.0] - 2026-06-13
 
 ### Features


### PR DESCRIPTION
Bumps the `NArk` submodule gitlink `0f914ff` → `29d92af` (`arkade-os/dotnet-sdk` master, #137):

- Raises the `X-Build-Version` the SDK reports to arkd `0.9.7` → `0.9.9` (matches arkd `v0.9.9`).
- Adds SDK-side real-rotation E2E coverage (destination-disable, sweep-migration, past-cutoff-held-back) — **test-only, no plugin-runtime change**.

Plugin `2.4.0` → `2.4.1` + CHANGELOG entry.