### PR TITLE
chore: bump NArk to X-SDK-VERSION header (plugin 2.4.2)

### DIFF
--- a/BTCPayServer.Plugins.ArkPayServer/BTCPayServer.Plugins.ArkPayServer.csproj
+++ b/BTCPayServer.Plugins.ArkPayServer/BTCPayServer.Plugins.ArkPayServer.csproj
@@ -7,7 +7,7 @@
 
         <Product>Arkade - Beta</Product>
         <Description>Programmable money for sovereign business. Easily accept payments through Arkade &amp; Lightning non-custodially without complexity.</Description>
-        <Version>2.4.1</Version>
+        <Version>2.4.2</Version>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
         <GenerateRuntimeConfigDevFile>true</GenerateRuntimeConfigDevFile>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.4.2] - 2026-06-15
+
+### SDK (NNark)
+- **Bumped to `arkade-os/dotnet-sdk` master @ `0b8d299` (#139).** Every gRPC and REST request now also carries an `X-SDK-VERSION` header reporting the SDK's own version as a `dotnet-sdk/{version}` product token (e.g. `dotnet-sdk/1.0.327-beta`), alongside the existing `X-Build-Version` (the arkd build the SDK targets). The version comes from Nerdbank.GitVersioning with the `+commit` build-metadata stripped; it lets arkd distinguish the .NET SDK from other SDKs and log the calling version for diagnostics. SDK-only, no plugin-runtime change.
+
 ## [2.4.1] - 2026-06-14
 
 ### SDK (NNark)


### PR DESCRIPTION
## Summary

Bumps the NNark submodule to `arkade-os/dotnet-sdk` master @ `0b8d299` ([dotnet-sdk#139](https://github.com/arkade-os/dotnet-sdk/pull/139)) and releases plugin **2.4.2**.

The SDK change adds an `X-SDK-VERSION` header to every gRPC and REST request, reporting the SDK's own version as a `dotnet-sdk/{version}` product token (e.g. `dotnet-sdk/1.0.327-beta`), alongside the existing `X-Build-Version` (the arkd build the SDK targets). The version comes from Nerdbank.GitVersioning with the `+commit` build-metadata stripped, so arkd can distinguish the .NET SDK from other SDKs and log the calling version for diagnostics.

This is **SDK-only** — no plugin-runtime change. The diff since the last bump (`29d92af` @ 2.4.1) is exactly that one SDK commit.

## Changes
- `submodules/NNark` → `0b8d299`
- Plugin version `2.4.1` → `2.4.2`
- `CHANGELOG.md`: new `[2.4.2]` entry

## Test plan
- dotnet-sdk#139 merged green: Build & Unit Tests, E2E Signer Rotation, and E2E Tests all passed on the SDK side before this bump.
- Relying on this repo's CI to build the plugin against the bumped submodule (no plugin code changed).