### PR TITLE
chore: require BTCPay Server 2.4.2 + Arkade Lightning spend authority (2.4.3)

### DIFF
--- a/BTCPayServer.Plugins.ArkPayServer/ArkPlugin.cs
+++ b/BTCPayServer.Plugins.ArkPayServer/ArkPlugin.cs
@@ -84,6 +84,7 @@ public class ArkadePlugin : BaseBTCPayServerPlugin
     private static void RegisterBtcPayServices(IServiceCollection services)
     {
         services.AddSingleton<ArkLightningSpendKeyService>();
+        services.AddHostedService<ArkLightningSpendKeyMigration>();
         services.AddSingleton<ILightningConnectionStringHandler, ArkLightningConnectionStringHandler>();
         services.AddSingleton<ArkadeLightningLimitsService>();
 

--- a/BTCPayServer.Plugins.ArkPayServer/ArkPlugin.cs
+++ b/BTCPayServer.Plugins.ArkPayServer/ArkPlugin.cs
@@ -47,7 +47,7 @@ public class ArkadePlugin : BaseBTCPayServerPlugin
 
     public override IBTCPayServerPlugin.PluginDependency[] Dependencies { get; } =
     [
-        new() { Identifier = nameof(BTCPayServer), Condition = ">=2.3.8" }
+        new() { Identifier = nameof(BTCPayServer), Condition = ">=2.4.2" }
     ];
 
     public override void Execute(IServiceCollection services)

--- a/BTCPayServer.Plugins.ArkPayServer/ArkPlugin.cs
+++ b/BTCPayServer.Plugins.ArkPayServer/ArkPlugin.cs
@@ -83,6 +83,7 @@ public class ArkadePlugin : BaseBTCPayServerPlugin
 
     private static void RegisterBtcPayServices(IServiceCollection services)
     {
+        services.AddSingleton<ArkLightningSpendKeyService>();
         services.AddSingleton<ILightningConnectionStringHandler, ArkLightningConnectionStringHandler>();
         services.AddSingleton<ArkadeLightningLimitsService>();
 

--- a/BTCPayServer.Plugins.ArkPayServer/BTCPayServer.Plugins.ArkPayServer.csproj
+++ b/BTCPayServer.Plugins.ArkPayServer/BTCPayServer.Plugins.ArkPayServer.csproj
@@ -7,7 +7,7 @@
 
         <Product>Arkade - Beta</Product>
         <Description>Programmable money for sovereign business. Easily accept payments through Arkade &amp; Lightning non-custodially without complexity.</Description>
-        <Version>2.4.2</Version>
+        <Version>2.4.3</Version>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
         <GenerateRuntimeConfigDevFile>true</GenerateRuntimeConfigDevFile>
@@ -49,25 +49,25 @@
         </ProjectReference>
         <!-- NNark transitive dependencies (must be explicit for plugin publish) -->
         <PackageReference Include="AsyncKeyedLock" Version="8.0.2" />
-        <PackageReference Include="BTCPayServer.Lightning.Common" Version="1.5.3" />
+        <PackageReference Include="BTCPayServer.Lightning.Common" Version="1.7.1" />
         <PackageReference Include="Cel" Version="0.3.2" />
         <PackageReference Include="Google.Api.CommonProtos" Version="2.17.0" />
         <PackageReference Include="Grpc.Net.Client" Version="2.76.0" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.6" />
         <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.6" />
         <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.6" />
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.6" />
-        <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.6" />
-        <PackageReference Include="NBitcoin" Version="10.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.10" />
+        <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.10" />
+        <PackageReference Include="NBitcoin" Version="10.0.8" />
         <PackageReference Include="NBitcoin.Secp256k1" Version="4.0.0" />
-        <PackageReference Include="NBXplorer.Client" Version="5.0.6" />
+        <PackageReference Include="NBXplorer.Client" Version="5.0.8" />
         <!-- Additional packages -->
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <PackageReference Include="Grpc.Net.ClientFactory" Version="2.76.0" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.6.0" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.6"/>
-        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.6" />
+        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.3" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
         <EmbeddedResource Include="Resources\**" />
         <EmbeddedResource Include="arkade.svg" />
     </ItemGroup>

--- a/BTCPayServer.Plugins.ArkPayServer/Controllers/ArkController.cs
+++ b/BTCPayServer.Plugins.ArkPayServer/Controllers/ArkController.cs
@@ -83,6 +83,7 @@ public class ArkController(
     ISwapStorage swapStorage,
     IVtxoStorage vtxoStorage,
     IWalletStorage walletStorage,
+    ArkLightningSpendKeyService spendKeyService,
     IDbContextFactory<ArkPluginDbContext> dbContextFactory,
     IHttpClientFactory httpClientFactory,
     BoardingUtxoSyncService boardingUtxoSyncService,
@@ -200,7 +201,9 @@ public class ArkController(
                 
                 var lnConfig = new LightningPaymentMethodConfig()
                 {
-                    ConnectionString = $"type=arkade;wallet-id={config.WalletId}",
+                    ConnectionString = config.GeneratedByStore
+                        ? await spendKeyService.BuildConnectionStringAsync(config.WalletId)
+                        : ArkLightningSpendKeyService.BuildReceiveOnlyConnectionString(config.WalletId),
                 };
 
                 store.SetPaymentMethodConfig(paymentMethodHandlerDictionary[lightningPaymentMethodId], lnConfig);
@@ -2447,7 +2450,9 @@ public class ArkController(
 
         store!.SetPaymentMethodConfig(paymentMethodHandlerDictionary[lightningPaymentMethodId], new LightningPaymentMethodConfig
         {
-            ConnectionString = $"type=arkade;wallet-id={config!.WalletId}",
+            ConnectionString = config!.GeneratedByStore
+                ? await spendKeyService.BuildConnectionStringAsync(config.WalletId)
+                : ArkLightningSpendKeyService.BuildReceiveOnlyConnectionString(config.WalletId),
         });
         store.SetPaymentMethodConfig(paymentMethodHandlerDictionary[lnurlPaymentMethodId], new LNURLPaymentMethodConfig
         {
@@ -2461,6 +2466,57 @@ public class ArkController(
         store.SetStoreBlob(blob);
         await storeRepository.UpdateStore(store);
         return RedirectWithSuccess(nameof(StoreOverview), "Lightning enabled", new { storeId });
+    }
+
+    /// <summary>
+    /// Returns the wallet's Lightning connection string, including its spend capability, so
+    /// the owner can add the same wallet to another store they control.
+    ///
+    /// Gated on <c>requireOwnedByStore</c>: only a store with spend rights over the wallet
+    /// may read the capability.
+    /// </summary>
+    [HttpGet("stores/{storeId}/ln-connection-string")]
+    [Authorize(Policy = Policies.CanModifyStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
+    public async Task<IActionResult> LightningConnectionString(string storeId)
+    {
+        var (_, config, errorResult) = await ValidateStoreAndConfig(requireOwnedByStore: true);
+        if (errorResult != null) return errorResult;
+
+        return Ok(new
+        {
+            connectionString = await spendKeyService.BuildConnectionStringAsync(
+                config!.WalletId, HttpContext.RequestAborted)
+        });
+    }
+
+    /// <summary>
+    /// Issues a fresh spend capability for the wallet. Connection strings previously shared
+    /// with other stores stop authorising spends and must be re-copied.
+    /// </summary>
+    [HttpPost("stores/{storeId}/regenerate-ln-spend-key")]
+    [Authorize(Policy = Policies.CanModifyStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
+    public async Task<IActionResult> RegenerateLightningSpendKey(string storeId)
+    {
+        var (store, config, errorResult) = await ValidateStoreAndConfig(requireOwnedByStore: true);
+        if (errorResult != null) return errorResult;
+
+        await spendKeyService.RegenerateAsync(config!.WalletId, HttpContext.RequestAborted);
+
+        // Re-issue this store's own connection string so it keeps working with the new value.
+        var lightningPaymentMethodId = GetLightningPaymentMethod();
+        var lnConfig = store!.GetPaymentMethodConfig<LightningPaymentMethodConfig>(
+            lightningPaymentMethodId, paymentMethodHandlerDictionary);
+        if (lnConfig?.ConnectionString?.StartsWith("type=arkade", StringComparison.InvariantCultureIgnoreCase) is true)
+        {
+            lnConfig.ConnectionString = await spendKeyService.BuildConnectionStringAsync(
+                config.WalletId, HttpContext.RequestAborted);
+            store.SetPaymentMethodConfig(paymentMethodHandlerDictionary[lightningPaymentMethodId], lnConfig);
+            await storeRepository.UpdateStore(store);
+        }
+
+        return RedirectWithSuccess(nameof(StoreOverview),
+            "Spend key regenerated. Connection strings shared with other stores must be updated.",
+            new { storeId });
     }
 
     [HttpPost("stores/{storeId}/disable-ln")]

--- a/BTCPayServer.Plugins.ArkPayServer/Controllers/ArkGreenfieldController.cs
+++ b/BTCPayServer.Plugins.ArkPayServer/Controllers/ArkGreenfieldController.cs
@@ -7,6 +7,7 @@ using BTCPayServer.Lightning;
 using BTCPayServer.Payments;
 using BTCPayServer.Payments.Lightning;
 using BTCPayServer.Plugins.ArkPayServer.Exceptions;
+using BTCPayServer.Plugins.ArkPayServer.Lightning;
 using BTCPayServer.Plugins.ArkPayServer.Models;
 using BTCPayServer.Plugins.ArkPayServer.Models.Api;
 using BTCPayServer.Plugins.ArkPayServer.Models.Api.Greenfield;
@@ -63,6 +64,7 @@ public class ArkGreenfieldController(
     ISwapStorage swapStorage,
     IVtxoStorage vtxoStorage,
     IWalletStorage walletStorage,
+    ArkLightningSpendKeyService spendKeyService,
     IWalletProvider walletProvider,
     IIntentStorage intentStorage,
     BoardingUtxoSyncService boardingUtxoSyncService,
@@ -173,7 +175,7 @@ public class ArkGreenfieldController(
             var lightningEnabled = false;
             if (request.EnableLightning)
             {
-                lightningEnabled = ConfigureLightning(store, walletId!);
+                lightningEnabled = await ConfigureLightning(store, walletId!, isNew, cancellationToken);
             }
 
             await storeRepository.UpdateStore(store);
@@ -1402,7 +1404,8 @@ public class ArkGreenfieldController(
             "Unsupported wallet input. Provide a BIP-39 mnemonic (12/24 words), nsec key, Ark address, or existing wallet ID.");
     }
 
-    private bool ConfigureLightning(StoreData store, string walletId)
+    private async Task<bool> ConfigureLightning(StoreData store, string walletId, bool generatedByStore,
+        CancellationToken cancellationToken)
     {
         var lightningPaymentMethodId = PaymentTypes.LN.GetPaymentMethodId("BTC");
         var existingLnConfig = store.GetPaymentMethodConfig<LightningPaymentMethodConfig>(
@@ -1413,7 +1416,9 @@ public class ArkGreenfieldController(
 
         var lnConfig = new LightningPaymentMethodConfig
         {
-            ConnectionString = $"type=arkade;wallet-id={walletId}",
+            ConnectionString = generatedByStore
+                ? await spendKeyService.BuildConnectionStringAsync(walletId, cancellationToken)
+                : ArkLightningSpendKeyService.BuildReceiveOnlyConnectionString(walletId),
         };
 
         store.SetPaymentMethodConfig(paymentMethodHandlerDictionary[lightningPaymentMethodId], lnConfig);

--- a/BTCPayServer.Plugins.ArkPayServer/Lightning/ArkLightningClient.cs
+++ b/BTCPayServer.Plugins.ArkPayServer/Lightning/ArkLightningClient.cs
@@ -1,4 +1,6 @@
 using System.ComponentModel.DataAnnotations;
+using System.Security.Cryptography;
+using System.Text;
 using BTCPayServer.Lightning;
 using BTCPayServer.Payments.Lightning;
 using BTCPayServer.Services.Invoices;
@@ -22,6 +24,7 @@ public class ArkLightningClient(
     IClientTransport clientTransport,
     Network network,
     string walletId,
+    ArkLightningSpendCapability spendCapability,
     SwapsManagementService swapsManagementService,
     BoltzLimitsValidator boltzLimitsValidator,
     ISwapStorage swapStorage,
@@ -29,10 +32,32 @@ public class ArkLightningClient(
     ISpendingService spendingService,
     IBitcoinBlockchain chainTimeProvider,
     IWalletStorage walletStorage,
+    ArkLightningSpendKeyService spendKeyService,
     ILogger<ArkLightningInvoiceListener> logger) : IExtendedLightningClient
 {
     /// <summary>Wallet-level metadata key holding the configured <see cref="ReverseSwapFeePayer"/>.</summary>
     public const string ReverseSwapFeePayerMetadataKey = "arkade.reverseSwapFeePayer";
+
+    /// <summary>
+    /// Wallet-level metadata key holding the Lightning spend capability.
+    /// See <see cref="ArkLightningSpendCapability"/>.
+    /// </summary>
+    public const string SpendKeyMetadataKey = "arkade.lightning.spendKey";
+
+    /// <summary>
+    /// Throws unless the caller presented the spend capability for this wallet.
+    /// </summary>
+    private async Task EnsureSpendAuthorized(CancellationToken cancellation)
+    {
+        if (await spendKeyService.VerifyAsync(walletId, spendCapability.Value, cancellation))
+            return;
+
+        logger.LogWarning(
+            "Rejected an Arkade Lightning spend for wallet {WalletId}: no valid spend " +
+            "capability was presented.", walletId);
+        throw new UnauthorizedAccessException(
+            "This store is not authorised to spend from the configured Arkade wallet.");
+    }
 
     private async Task<ReverseSwapFeePayer> ResolveReverseSwapFeePayer(CancellationToken cancellation)
     {
@@ -245,6 +270,8 @@ public class ArkLightningClient(
     public async Task<LightningInvoice> CreateInvoice(CreateInvoiceParams createInvoiceRequest,
         CancellationToken cancellation = default)
     {
+        await EnsureSpendAuthorized(cancellation);
+
         var terms = await clientTransport.GetServerInfoAsync(cancellation);
         if (terms.Dust > createInvoiceRequest.Amount)
         {
@@ -314,6 +341,8 @@ public class ArkLightningClient(
 
     public async Task<PayResponse> Pay(string bolt11, PayInvoiceParams payParams, CancellationToken cancellation = default)
     {
+        await EnsureSpendAuthorized(cancellation);
+
         try
         {
             if (string.IsNullOrEmpty(bolt11))

--- a/BTCPayServer.Plugins.ArkPayServer/Lightning/ArkLightningConnectionStringHandler.cs
+++ b/BTCPayServer.Plugins.ArkPayServer/Lightning/ArkLightningConnectionStringHandler.cs
@@ -21,8 +21,12 @@ public class ArkLightningConnectionStringHandler(IServiceProvider serviceProvide
             return null;
         }
 
+        // Optional. Absence yields a receive-only client rather than an error.
+        kv.TryGetValue("spend-key", out var spendKey);
+
         error = null;
-        return ActivatorUtilities.CreateInstance<ArkLightningClient>(serviceProvider, network, walletId);
+        return ActivatorUtilities.CreateInstance<ArkLightningClient>(
+            serviceProvider, network, walletId, new ArkLightningSpendCapability(spendKey));
     }
 }
 

--- a/BTCPayServer.Plugins.ArkPayServer/Lightning/ArkLightningSpendCapability.cs
+++ b/BTCPayServer.Plugins.ArkPayServer/Lightning/ArkLightningSpendCapability.cs
@@ -1,0 +1,16 @@
+namespace BTCPayServer.Plugins.ArkPayServer.Lightning;
+
+/// <summary>
+/// Capability authorising spend operations on an Arkade wallet through the Lightning
+/// connection string.
+///
+/// Issued to the store that generates a wallet and presented back via the connection
+/// string's <c>spend-key</c>. Stores that reference a wallet by id get a receive-only
+/// client.
+///
+/// Wrapped in a dedicated type rather than passed as a bare <see cref="string"/> because
+/// <c>ActivatorUtilities.CreateInstance</c> binds constructor arguments by type — a second
+/// <see cref="string"/> parameter alongside the wallet id could bind in either order.
+/// </summary>
+/// <param name="Value">The capability, or <c>null</c> when the caller presented none.</param>
+public sealed record ArkLightningSpendCapability(string? Value);

--- a/BTCPayServer.Plugins.ArkPayServer/Lightning/ArkLightningSpendKeyMigration.cs
+++ b/BTCPayServer.Plugins.ArkPayServer/Lightning/ArkLightningSpendKeyMigration.cs
@@ -1,0 +1,82 @@
+using BTCPayServer.Data;
+using BTCPayServer.Payments;
+using BTCPayServer.Payments.Lightning;
+using BTCPayServer.Plugins.ArkPayServer.PaymentHandler;
+using BTCPayServer.Services.Invoices;
+using BTCPayServer.Services.Stores;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace BTCPayServer.Plugins.ArkPayServer.Lightning;
+
+/// <summary>
+/// Backfills the spend capability into Arkade Lightning connection strings written before
+/// capabilities existed, so stores configured earlier keep working.
+///
+/// A store is backfilled only when it owns the wallet it is configured against. Stores
+/// configured against a wallet they do not own are left receive-only.
+///
+/// Runs in the background rather than in <c>StartAsync</c> so a slow or failing pass never
+/// blocks host startup.
+/// </summary>
+public class ArkLightningSpendKeyMigration(
+    StoreRepository storeRepository,
+    PaymentMethodHandlerDictionary paymentMethodHandlerDictionary,
+    ArkLightningSpendKeyService spendKeyService,
+    ILogger<ArkLightningSpendKeyMigration> logger) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        try
+        {
+            var lightningPaymentMethodId = PaymentTypes.LN.GetPaymentMethodId("BTC");
+            var backfilled = 0;
+            var leftReceiveOnly = 0;
+
+            foreach (var store in await storeRepository.GetStores())
+            {
+                stoppingToken.ThrowIfCancellationRequested();
+
+                var lnConfig = store.GetPaymentMethodConfig<LightningPaymentMethodConfig>(
+                    lightningPaymentMethodId, paymentMethodHandlerDictionary);
+
+                var connectionString = lnConfig?.ConnectionString;
+                if (connectionString?.StartsWith("type=arkade", StringComparison.InvariantCultureIgnoreCase) is not true)
+                    continue;
+                if (connectionString.Contains("spend-key=", StringComparison.InvariantCultureIgnoreCase))
+                    continue;
+
+                var arkConfig = store.GetPaymentMethodConfig<ArkadePaymentMethodConfig>(
+                    ArkadePlugin.ArkadePaymentMethodId, paymentMethodHandlerDictionary);
+                if (arkConfig?.WalletId is null)
+                    continue;
+
+                if (!arkConfig.GeneratedByStore)
+                {
+                    leftReceiveOnly++;
+                    continue;
+                }
+
+                lnConfig!.ConnectionString = await spendKeyService.BuildConnectionStringAsync(
+                    arkConfig.WalletId, stoppingToken);
+                store.SetPaymentMethodConfig(
+                    paymentMethodHandlerDictionary[lightningPaymentMethodId], lnConfig);
+                await storeRepository.UpdateStore(store);
+                backfilled++;
+            }
+
+            if (backfilled > 0 || leftReceiveOnly > 0)
+                logger.LogInformation(
+                    "Arkade Lightning spend capability backfill complete: {Backfilled} store(s) " +
+                    "updated, {ReceiveOnly} left receive-only.", backfilled, leftReceiveOnly);
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            // Host shutting down.
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Arkade Lightning spend capability backfill failed.");
+        }
+    }
+}

--- a/BTCPayServer.Plugins.ArkPayServer/Lightning/ArkLightningSpendKeyService.cs
+++ b/BTCPayServer.Plugins.ArkPayServer/Lightning/ArkLightningSpendKeyService.cs
@@ -1,0 +1,99 @@
+using System.Collections.Concurrent;
+using System.Security.Cryptography;
+using System.Text;
+using NArk.Abstractions.Wallets;
+
+namespace BTCPayServer.Plugins.ArkPayServer.Lightning;
+
+/// <summary>
+/// Owns the per-wallet Lightning spend capability: issuing it, regenerating it, and verifying
+/// it on spend paths.
+///
+/// A wallet has exactly one capability, created on first use and stable thereafter, so the
+/// same connection string can be shared across the stores its owner controls. It is cached in
+/// memory — spend paths verify without a storage round trip — and the cache is written through
+/// on issue and regenerate.
+/// </summary>
+public class ArkLightningSpendKeyService(IWalletStorage walletStorage)
+{
+    private readonly ConcurrentDictionary<string, string> _cache = new();
+
+    /// <summary>
+    /// Returns the wallet's capability, creating one on first use.
+    /// </summary>
+    public async Task<string> GetOrCreateAsync(string walletId, CancellationToken cancellationToken = default)
+    {
+        if (_cache.TryGetValue(walletId, out var cached)) return cached;
+
+        var stored = await ReadStoredAsync(walletId, cancellationToken);
+        if (!string.IsNullOrEmpty(stored))
+        {
+            _cache[walletId] = stored;
+            return stored;
+        }
+
+        return await IssueAsync(walletId, cancellationToken);
+    }
+
+    /// <summary>
+    /// Issues a fresh capability for the wallet, superseding the previous one. Connection
+    /// strings already shared with other stores stop authorising spends.
+    /// </summary>
+    public Task<string> RegenerateAsync(string walletId, CancellationToken cancellationToken = default)
+        => IssueAsync(walletId, cancellationToken);
+
+    /// <summary>
+    /// Verifies a presented capability against the wallet's. Fails closed: a missing capability
+    /// on either side is never treated as permissive.
+    /// </summary>
+    public async Task<bool> VerifyAsync(string walletId, string? presented,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrEmpty(presented)) return false;
+
+        if (!_cache.TryGetValue(walletId, out var expected))
+        {
+            expected = await ReadStoredAsync(walletId, cancellationToken);
+            if (!string.IsNullOrEmpty(expected)) _cache[walletId] = expected;
+        }
+
+        if (string.IsNullOrEmpty(expected)) return false;
+
+        return CryptographicOperations.FixedTimeEquals(
+            Encoding.UTF8.GetBytes(expected), Encoding.UTF8.GetBytes(presented));
+    }
+
+    /// <summary>
+    /// Builds the connection string carrying the wallet's capability. This is the value shown
+    /// to an owner for adding the wallet to another store they control.
+    /// </summary>
+    public async Task<string> BuildConnectionStringAsync(string walletId,
+        CancellationToken cancellationToken = default)
+        => $"{BuildReceiveOnlyConnectionString(walletId)};spend-key={await GetOrCreateAsync(walletId, cancellationToken)}";
+
+    /// <summary>
+    /// Builds a connection string without a capability. Such a client can watch and receive
+    /// but not spend.
+    /// </summary>
+    public static string BuildReceiveOnlyConnectionString(string walletId)
+        => $"type=arkade;wallet-id={walletId}";
+
+    private async Task<string?> ReadStoredAsync(string walletId, CancellationToken cancellationToken)
+    {
+        var wallet = await walletStorage.GetWalletById(walletId, cancellationToken);
+        return wallet?.Metadata?.TryGetValue(ArkLightningClient.SpendKeyMetadataKey, out var stored) is true
+            ? stored
+            : null;
+    }
+
+    private async Task<string> IssueAsync(string walletId, CancellationToken cancellationToken)
+    {
+        // Hex rather than base64: the value has to survive `key=value;` parsing, and base64's
+        // '=' padding would truncate it.
+        var key = Convert.ToHexString(RandomNumberGenerator.GetBytes(32));
+        await walletStorage.SetMetadataValue(
+            walletId, ArkLightningClient.SpendKeyMetadataKey, key, cancellationToken);
+        _cache[walletId] = key;
+        return key;
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Breaking Changes
 - **Minimum BTCPay Server version raised to 2.4.2** (up from 2.3.8). The plugin is now built against BTCPay Server 2.4.2 and declares `>=2.4.2`; stores running an older BTCPay will not load it. Upgrading BTCPay also picks up the upstream fixes released across 2.3.9–2.4.2.
 
+### Features
+- **Arkade Lightning spend authority is now explicit.** A wallet carries a spend capability that its owning store's connection string presents on spend paths; connection strings without it can receive and report but not pay. The capability is visible to a store with spend rights over the wallet, so the same wallet can be added to other stores you control by copying the connection string, and it can be regenerated to withdraw that access. Existing setups are backfilled automatically on startup.
+
 ### Compatibility
 - **Package pins realigned with the host.** The plugin mirrors BTCPayServer's own dependency versions so the two agree in-process; 2.4.2 moved several of them, so the mirror was updated to match: Roslyn Workspaces `5.6.0`, `NBitcoin` `10.0.8`, `NBXplorer.Client` `5.0.8`, `Npgsql.EntityFrameworkCore.PostgreSQL` `10.0.3`, `BTCPayServer.Lightning.Common` `1.7.1`, and the `Microsoft.Extensions.*` family at `10.0.10`.
 - **E2E suite moved to xunit v3** (`xunit.v3` `3.2.2`, `Microsoft.NET.Test.Sdk` `18.8.1`, `Microsoft.Playwright` `1.61.0`), matching `BTCPayServer.Tests` — running both xunit generations in one compilation made every `[Fact]` ambiguous. Also updated for the Greenfield client dropping the `storeId` parameter from `ApprovePayout`, `GetStorePayout`, and `GetInvoice`. Test-only, no plugin-runtime change.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [2.4.3] - 2026-08-18
+
+### Breaking Changes
+- **Minimum BTCPay Server version raised to 2.4.2** (up from 2.3.8). The plugin is now built against BTCPay Server 2.4.2 and declares `>=2.4.2`; stores running an older BTCPay will not load it. Upgrading BTCPay also picks up the upstream fixes released across 2.3.9–2.4.2.
+
+### Compatibility
+- **Package pins realigned with the host.** The plugin mirrors BTCPayServer's own dependency versions so the two agree in-process; 2.4.2 moved several of them, so the mirror was updated to match: Roslyn Workspaces `5.6.0`, `NBitcoin` `10.0.8`, `NBXplorer.Client` `5.0.8`, `Npgsql.EntityFrameworkCore.PostgreSQL` `10.0.3`, `BTCPayServer.Lightning.Common` `1.7.1`, and the `Microsoft.Extensions.*` family at `10.0.10`.
+- **E2E suite moved to xunit v3** (`xunit.v3` `3.2.2`, `Microsoft.NET.Test.Sdk` `18.8.1`, `Microsoft.Playwright` `1.61.0`), matching `BTCPayServer.Tests` — running both xunit generations in one compilation made every `[Fact]` ambiguous. Also updated for the Greenfield client dropping the `storeId` parameter from `ApprovePayout`, `GetStorePayout`, and `GetInvoice`. Test-only, no plugin-runtime change.
+
 ## [2.4.2] - 2026-06-15
 
 ### SDK (NNark)

--- a/NArk.E2E.Tests/ApiEndpointTests.cs
+++ b/NArk.E2E.Tests/ApiEndpointTests.cs
@@ -2,7 +2,6 @@ using System.Text.Json;
 using Microsoft.Playwright;
 using NBitcoin;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace NArk.E2E.Tests;
 

--- a/NArk.E2E.Tests/FundedWalletTests.cs
+++ b/NArk.E2E.Tests/FundedWalletTests.cs
@@ -2,7 +2,6 @@ using BTCPayServer.Client;
 using BTCPayServer.Client.Models;
 using Microsoft.Playwright;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace NArk.E2E.Tests;
 
@@ -137,13 +136,13 @@ public class FundedWalletTests : PlaywrightBaseTest
             PayoutMethodId = "ARKADE"
         });
         Assert.Equal(PayoutState.AwaitingApproval, payout.State);
-        await client.ApprovePayout(storeId, payout.Id, new ApprovePayoutRequest());
+        await client.ApprovePayout(payout.Id, new ApprovePayoutRequest());
 
         var deadline = DateTimeOffset.UtcNow + TimeSpan.FromMinutes(3);
         PayoutState last = PayoutState.AwaitingApproval;
         while (DateTimeOffset.UtcNow < deadline)
         {
-            var p = await client.GetStorePayout(storeId, payout.Id);
+            var p = await client.GetStorePayout(payout.Id);
             last = p.State;
             if (last is PayoutState.AwaitingPayment or PayoutState.InProgress or PayoutState.Completed)
                 return;

--- a/NArk.E2E.Tests/InvoicePaymentLatencyTests.cs
+++ b/NArk.E2E.Tests/InvoicePaymentLatencyTests.cs
@@ -5,7 +5,6 @@ using CliWrap;
 using CliWrap.Buffered;
 using Microsoft.Playwright;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace NArk.E2E.Tests;
 
@@ -134,7 +133,7 @@ public class InvoicePaymentLatencyTests : PlaywrightBaseTest
         InvoiceStatus lastStatus = InvoiceStatus.New;
         while (DateTimeOffset.UtcNow < deadline)
         {
-            var current = await client.GetInvoice(storeId, invoice.Id);
+            var current = await client.GetInvoice(invoice.Id);
             lastStatus = current.Status;
             if (current.Status == InvoiceStatus.Settled)
             {

--- a/NArk.E2E.Tests/NArk.E2E.Tests.csproj
+++ b/NArk.E2E.Tests/NArk.E2E.Tests.csproj
@@ -16,9 +16,9 @@
 
   <ItemGroup>
     <PackageReference Include="CliWrap" Version="3.10.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
-    <PackageReference Include="Microsoft.Playwright" Version="1.57.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="Microsoft.Playwright" Version="1.61.0" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/NArk.E2E.Tests/PageRenderTests.cs
+++ b/NArk.E2E.Tests/PageRenderTests.cs
@@ -1,6 +1,5 @@
 using Microsoft.Playwright;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace NArk.E2E.Tests;
 

--- a/NArk.E2E.Tests/PayoutTests.cs
+++ b/NArk.E2E.Tests/PayoutTests.cs
@@ -1,7 +1,6 @@
 using BTCPayServer.Client;
 using BTCPayServer.Client.Models;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace NArk.E2E.Tests;
 

--- a/NArk.E2E.Tests/PlaywrightBaseTest.cs
+++ b/NArk.E2E.Tests/PlaywrightBaseTest.cs
@@ -6,7 +6,7 @@ using NArk.Core.Services;
 using NBitcoin;
 using NBitcoin.DataEncoders;
 using NBitcoin.Secp256k1;
-using Xunit.Abstractions;
+using Xunit;
 
 namespace NArk.E2E.Tests;
 

--- a/NArk.E2E.Tests/ReverseSwapFeePayerTests.cs
+++ b/NArk.E2E.Tests/ReverseSwapFeePayerTests.cs
@@ -4,7 +4,6 @@ using Microsoft.Playwright;
 using NArk.Abstractions.Wallets;
 using NArk.Swaps.Models;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace NArk.E2E.Tests;
 

--- a/NArk.E2E.Tests/SpendingTests.cs
+++ b/NArk.E2E.Tests/SpendingTests.cs
@@ -1,7 +1,6 @@
 using System.Text.Json;
 using Microsoft.Playwright;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace NArk.E2E.Tests;
 

--- a/NArk.E2E.Tests/SwapsTests.cs
+++ b/NArk.E2E.Tests/SwapsTests.cs
@@ -4,7 +4,6 @@ using NArk.Swaps.Abstractions;
 using NArk.Swaps.Models;
 using NArk.Tests.End2End.Common;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace NArk.E2E.Tests;
 

--- a/NArk.E2E.Tests/WalletSetupTests.cs
+++ b/NArk.E2E.Tests/WalletSetupTests.cs
@@ -1,7 +1,6 @@
 using Microsoft.Playwright;
 using NBitcoin;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace NArk.E2E.Tests;
 

--- a/NArk.Tests/ArkLightningSpendKeyServiceTests.cs
+++ b/NArk.Tests/ArkLightningSpendKeyServiceTests.cs
@@ -1,0 +1,157 @@
+using BTCPayServer.Plugins.ArkPayServer.Lightning;
+using NArk.Abstractions.Wallets;
+using Xunit;
+
+namespace NArk.Tests;
+
+/// <summary>
+/// Covers the authorization boundary the Arkade Lightning client relies on: a connection
+/// string only authorises spending when it carries the capability issued for that wallet.
+/// </summary>
+public class ArkLightningSpendKeyServiceTests
+{
+    private const string WalletId = "wallet-under-test";
+
+    private static ArkLightningSpendKeyService NewService() => new(new FakeWalletStorage());
+
+    [Fact]
+    public async Task Verify_RejectsWhenNoCapabilityHasBeenIssued()
+    {
+        var service = NewService();
+
+        // Nothing issued for this wallet, so no presented value can authorise a spend.
+        Assert.False(await service.VerifyAsync(WalletId, "any-value-at-all"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public async Task Verify_RejectsAbsentCapability(string? presented)
+    {
+        var service = NewService();
+        await service.GetOrCreateAsync(WalletId);
+
+        Assert.False(await service.VerifyAsync(WalletId, presented));
+    }
+
+    [Fact]
+    public async Task Verify_RejectsWrongCapability()
+    {
+        var service = NewService();
+        await service.GetOrCreateAsync(WalletId);
+
+        Assert.False(await service.VerifyAsync(WalletId, "0000000000000000000000000000000000000000000000000000000000000000"));
+    }
+
+    [Fact]
+    public async Task Verify_RejectsCapabilityBelongingToAnotherWallet()
+    {
+        var service = NewService();
+        var othersCapability = await service.GetOrCreateAsync("wallet-owned-by-someone-else");
+        await service.GetOrCreateAsync(WalletId);
+
+        // Holding a capability for one wallet must not authorise spending a different one.
+        Assert.False(await service.VerifyAsync(WalletId, othersCapability));
+    }
+
+    [Fact]
+    public async Task Verify_AcceptsIssuedCapability()
+    {
+        var service = NewService();
+        var capability = await service.GetOrCreateAsync(WalletId);
+
+        Assert.True(await service.VerifyAsync(WalletId, capability));
+    }
+
+    [Fact]
+    public async Task GetOrCreate_ReturnsOneStableCapabilityPerWallet()
+    {
+        var service = NewService();
+
+        // Stability is what lets an owner share one connection string across their stores.
+        Assert.Equal(await service.GetOrCreateAsync(WalletId), await service.GetOrCreateAsync(WalletId));
+    }
+
+    [Fact]
+    public async Task GetOrCreate_ReadsBackACapabilityIssuedBeforeThisProcess()
+    {
+        var storage = new FakeWalletStorage();
+        var issued = await new ArkLightningSpendKeyService(storage).GetOrCreateAsync(WalletId);
+
+        // A fresh instance shares no cache, so this exercises the storage read path.
+        var afterRestart = new ArkLightningSpendKeyService(storage);
+
+        Assert.Equal(issued, await afterRestart.GetOrCreateAsync(WalletId));
+        Assert.True(await afterRestart.VerifyAsync(WalletId, issued));
+    }
+
+    [Fact]
+    public async Task Regenerate_SupersedesThePreviousCapability()
+    {
+        var service = NewService();
+        var superseded = await service.GetOrCreateAsync(WalletId);
+
+        var current = await service.RegenerateAsync(WalletId);
+
+        Assert.NotEqual(superseded, current);
+        Assert.False(await service.VerifyAsync(WalletId, superseded));
+        Assert.True(await service.VerifyAsync(WalletId, current));
+    }
+
+    [Fact]
+    public async Task ConnectionString_CarriesTheCapabilityOnlyWhenBuiltForAnOwner()
+    {
+        var service = NewService();
+
+        var receiveOnly = ArkLightningSpendKeyService.BuildReceiveOnlyConnectionString(WalletId);
+        Assert.DoesNotContain("spend-key", receiveOnly, StringComparison.OrdinalIgnoreCase);
+
+        var full = await service.BuildConnectionStringAsync(WalletId);
+        Assert.Contains($"spend-key={await service.GetOrCreateAsync(WalletId)}", full);
+    }
+
+    /// <summary>
+    /// In-memory <see cref="IWalletStorage"/> covering only the members the service uses; the
+    /// rest throw so an unexpected dependency shows up as a failure rather than a silent pass.
+    /// </summary>
+    private sealed class FakeWalletStorage : IWalletStorage
+    {
+        private readonly Dictionary<string, Dictionary<string, string>> _metadata = new();
+
+        public Task<ArkWalletInfo?> GetWalletById(string walletId, CancellationToken ct = default)
+            => Task.FromResult<ArkWalletInfo?>(new ArkWalletInfo(
+                walletId, null, null, WalletType.SingleKey, null, 0,
+                _metadata.TryGetValue(walletId, out var metadata) ? metadata : null));
+
+        public Task SetMetadataValue(string walletId, string key, string? value, CancellationToken ct = default)
+        {
+            if (!_metadata.TryGetValue(walletId, out var metadata))
+                _metadata[walletId] = metadata = new Dictionary<string, string>();
+
+            if (value is null) metadata.Remove(key);
+            else metadata[key] = value;
+
+            return Task.CompletedTask;
+        }
+
+        public event EventHandler<ArkWalletInfo>? WalletSaved { add { } remove { } }
+        public event EventHandler<string>? WalletDeleted { add { } remove { } }
+
+        public Task<ArkWalletInfo> LoadWallet(string walletIdentifierOrFingerprint, CancellationToken ct = default)
+            => throw new NotSupportedException();
+        public Task<IReadOnlySet<ArkWalletInfo>> LoadAllWallets(CancellationToken ct = default)
+            => throw new NotSupportedException();
+        public Task SaveWallet(ArkWalletInfo wallet, CancellationToken ct = default)
+            => throw new NotSupportedException();
+        public Task UpdateLastUsedIndex(string walletId, int lastUsedIndex, CancellationToken ct = default)
+            => throw new NotSupportedException();
+        public Task<IReadOnlyList<ArkWalletInfo>> GetWalletsByIds(IEnumerable<string> walletIds, CancellationToken ct = default)
+            => throw new NotSupportedException();
+        public Task<bool> UpsertWallet(ArkWalletInfo wallet, bool updateIfExists = true, CancellationToken ct = default)
+            => throw new NotSupportedException();
+        public Task<bool> DeleteWallet(string walletId, CancellationToken ct = default)
+            => throw new NotSupportedException();
+        public Task UpdateDestination(string walletId, string? destination, CancellationToken ct = default)
+            => throw new NotSupportedException();
+    }
+}

--- a/NArk.Tests/NArk.Tests.csproj
+++ b/NArk.Tests/NArk.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <!-- Matches BTCPayServer.Tests: these tests pass no CancellationToken by design. -->
+    <NoWarn>$(NoWarn),xUnit1031,xUnit1051</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\BTCPayServer.Plugins.ArkPayServer\BTCPayServer.Plugins.ArkPayServer.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/NArk.sln
+++ b/NArk.sln
@@ -28,6 +28,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NArk.Swaps", "submodules\NN
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NArk.Storage.EfCore", "submodules\NNark\NArk.Storage.EfCore\NArk.Storage.EfCore.csproj", "{11DF32A5-0825-4703-9F8A-4ED7CA84F0BD}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NArk.Tests", "NArk.Tests\NArk.Tests.csproj", "{E5569F16-26D0-4314-8D71-7964CCFE9F68}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -170,6 +172,18 @@ Global
 		{11DF32A5-0825-4703-9F8A-4ED7CA84F0BD}.Release|x64.Build.0 = Release|Any CPU
 		{11DF32A5-0825-4703-9F8A-4ED7CA84F0BD}.Release|x86.ActiveCfg = Release|Any CPU
 		{11DF32A5-0825-4703-9F8A-4ED7CA84F0BD}.Release|x86.Build.0 = Release|Any CPU
+		{E5569F16-26D0-4314-8D71-7964CCFE9F68}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E5569F16-26D0-4314-8D71-7964CCFE9F68}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E5569F16-26D0-4314-8D71-7964CCFE9F68}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E5569F16-26D0-4314-8D71-7964CCFE9F68}.Debug|x64.Build.0 = Debug|Any CPU
+		{E5569F16-26D0-4314-8D71-7964CCFE9F68}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E5569F16-26D0-4314-8D71-7964CCFE9F68}.Debug|x86.Build.0 = Debug|Any CPU
+		{E5569F16-26D0-4314-8D71-7964CCFE9F68}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E5569F16-26D0-4314-8D71-7964CCFE9F68}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E5569F16-26D0-4314-8D71-7964CCFE9F68}.Release|x64.ActiveCfg = Release|Any CPU
+		{E5569F16-26D0-4314-8D71-7964CCFE9F68}.Release|x64.Build.0 = Release|Any CPU
+		{E5569F16-26D0-4314-8D71-7964CCFE9F68}.Release|x86.ActiveCfg = Release|Any CPU
+		{E5569F16-26D0-4314-8D71-7964CCFE9F68}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
**Draft — not mergeable yet.** See "Outstanding" below.

Two changes, shipping together as 2.4.3.

## 1. Require BTCPay Server 2.4.2

Bumps the `btcpayserver` submodule `v2.3.8` → `v2.4.2` and raises the plugin's declared floor to `>=2.4.2`.

The plugin mirrors BTCPayServer's own dependency versions so the two agree in-process. 2.4.2 (186 commits on) moved several, breaking the mirror in four layers:

| Error | Cause |
|---|---|
| `NU1107` | `BTCPayServer.Rating` moved to Roslyn 5.6.0; plugin pinned Workspaces 5.3.0, which has an **exact** dep on CSharp 5.3.0 |
| `NU1605` ×7 | 2.4.2 raised floors above the plugin's explicit pins |
| `CS0433` ×74 | `BTCPayServer.Tests` migrated **xunit v2 → v3**; both generations in one compilation made every `[Fact]` ambiguous |
| `CS1503` ×4 | Greenfield client dropped the `storeId` parameter from `ApprovePayout`, `GetStorePayout`, `GetInvoice` |

At v2.3.8 BTCPay pinned byte-identical versions (Roslyn 5.3.0, Test.Sdk 18.4.0, Playwright 1.57.0, xunit 2.9.3) — these were mirror drift, not the plugin lagging.

- Pins realigned: Roslyn Workspaces `5.6.0`, `NBitcoin` `10.0.8`, `NBXplorer.Client` `5.0.8`, `Npgsql.EFCore.PostgreSQL` `10.0.3`, `BTCPayServer.Lightning.Common` `1.7.1`, `Microsoft.Extensions.*` `10.0.10`
- E2E → `xunit.v3` `3.2.2`, `Test.Sdk` `18.8.1`, `Playwright` `1.61.0`

**Breaking:** stores on BTCPay older than 2.4.2 will no longer load the plugin.

## 2. Bind Arkade Lightning spend authority to the configuring store

Spend paths on the Arkade Lightning client now require a capability issued to the store that generates a wallet, carried in the connection string as `spend-key`. Stores that reference a wallet by id get a receive-only client — balance, invoice, payment and listener paths keep working; `Pay` and `CreateInvoice` do not.

- 256-bit hex (base64 padding would not survive `key=value;` parsing), constant-time compared, excluded from `ToString()` so it cannot reach logs or the UI
- Returning payment-method `Config` requires `CanModifyStore`, so the capability is not exposed to view-only credentials
- Issuing rotates any previous value, which doubles as revocation
- Wrapped in a dedicated type because `ActivatorUtilities` binds constructor args by type — a second bare `string` could bind in either order

## Outstanding — blocks merge

- [ ] **Startup migration.** Existing connection strings predate the capability, so deployed stores would lose `Pay`/`CreateInvoice`. Needs a service that enumerates stores and issues for those whose `ArkadePaymentMethodConfig.GeneratedByStore` is true. **Without this, merging is a fund-availability regression.**
- [ ] Regression test covering the authorization boundary
- [ ] `ArkLightningClient.ToString()` omits the capability — good for hygiene, but a round-trip through it would strip spend authority from a legitimate owner. Follow-up.

## Test plan

Baselines captured before any change:

| Gate | Baseline (v2.3.8) | This branch |
|---|---|---|
| `dotnet build NArk.sln -m:1` | 0 errors | **0 errors** |
| `NArk.E2E.Tests` | green (`e2e` success on master `c0b8171`) | **0 errors** |
| CI `build` | — | **pass** |
| CI `E2E Tests` | — | **pass** (9m22s on re-run; first run hit the known `no spendable coins within the wait window` funding flake) |

Build verified against the artifact, not just exit code: `BTCPayServer.dll` reports `ProductVersion 2.4.2+fbf761f36a...`.

CI results above predate the Lightning commit; they re-run on this push.